### PR TITLE
Autofocus input

### DIFF
--- a/src/components/chat-view/chat-input/ChatUserInput.tsx
+++ b/src/components/chat-view/chat-input/ChatUserInput.tsx
@@ -1,4 +1,3 @@
-import { AutoFocusPlugin } from '@lexical/react/LexicalAutoFocusPlugin'
 import {
   InitialConfigType,
   LexicalComposer,
@@ -34,6 +33,7 @@ import { MemoizedSyntaxHighlighterWrapper } from '../SyntaxHighlighterWrapper'
 
 import MentionableBadge from './MentionableBadge'
 import { ModelSelect } from './ModelSelect'
+import AutoFocusPlugin from './plugins/auto-focus/AutoFocusPlugin'
 import AutoLinkMentionPlugin from './plugins/mention/AutoLinkMentionPlugin'
 import { MentionNode } from './plugins/mention/MentionNode'
 import MentionPlugin from './plugins/mention/MentionPlugin'
@@ -318,7 +318,7 @@ const ChatUserInput = forwardRef<ChatUserInputRef, ChatUserInputProps>(
             ErrorBoundary={LexicalErrorBoundary}
           />
           <HistoryPlugin />
-          {autoFocus && <AutoFocusPlugin />}
+          {autoFocus && <AutoFocusPlugin defaultSelection="rootEnd" />}
           <MentionPlugin searchResultByQuery={searchResultByQuery} />
           <OnChangePlugin
             onChange={(editorState) => {

--- a/src/components/chat-view/chat-input/plugins/auto-focus/AutoFocusPlugin.tsx
+++ b/src/components/chat-view/chat-input/plugins/auto-focus/AutoFocusPlugin.tsx
@@ -15,7 +15,7 @@ export default function AutoFocusPlugin({
       () => {
         const rootElement = editor.getRootElement()
         if (rootElement) {
-          // requestAnimationFrame ensures DOM is rendered
+          // requestAnimationFrame is required here for unknown reasons, possibly related to the Obsidian plugin environment.
           requestAnimationFrame(() => {
             rootElement.focus()
           })

--- a/src/components/chat-view/chat-input/plugins/auto-focus/AutoFocusPlugin.tsx
+++ b/src/components/chat-view/chat-input/plugins/auto-focus/AutoFocusPlugin.tsx
@@ -1,0 +1,29 @@
+import { useLexicalComposerContext } from '@lexical/react/LexicalComposerContext'
+import { useEffect } from 'react'
+
+export type AutoFocusPluginProps = {
+  defaultSelection?: 'rootStart' | 'rootEnd'
+}
+
+export default function AutoFocusPlugin({
+  defaultSelection,
+}: AutoFocusPluginProps) {
+  const [editor] = useLexicalComposerContext()
+
+  useEffect(() => {
+    editor.focus(
+      () => {
+        const rootElement = editor.getRootElement()
+        if (rootElement) {
+          // requestAnimationFrame ensures DOM is rendered
+          requestAnimationFrame(() => {
+            rootElement.focus()
+          })
+        }
+      },
+      { defaultSelection },
+    )
+  }, [defaultSelection, editor])
+
+  return null
+}


### PR DESCRIPTION
Implemented custom AutoFocusPlugin.

### Problem in Lexical's AutoFocusPlugin
```javascript
if (rootElement !== null && (activeElement === null || !rootElement.contains(activeElement))) {
  // Note: preventScroll won't work in Webkit.
  rootElement.focus({
    preventScroll: true
  });
}
```
- In our use case, activeElement (MarkdownView) doesn't contain rootElement (ChatUserInput)