### PR TITLE
hotfix: pin pglite version to 0.2.12

### DIFF
--- a/src/database/DatabaseManager.ts
+++ b/src/database/DatabaseManager.ts
@@ -134,9 +134,14 @@ export class DatabaseManager {
     vectorExtensionBundlePath: URL
   }> {
     try {
+      const PGLITE_VERSION = '0.2.12'
       const [fsBundleResponse, wasmResponse] = await Promise.all([
-        requestUrl('https://unpkg.com/@electric-sql/pglite/dist/postgres.data'),
-        requestUrl('https://unpkg.com/@electric-sql/pglite/dist/postgres.wasm'),
+        requestUrl(
+          `https://unpkg.com/@electric-sql/pglite@${PGLITE_VERSION}/dist/postgres.data`,
+        ),
+        requestUrl(
+          `https://unpkg.com/@electric-sql/pglite@${PGLITE_VERSION}/dist/postgres.wasm`,
+        ),
       ])
 
       const fsBundle = new Blob([fsBundleResponse.arrayBuffer], {
@@ -144,7 +149,7 @@ export class DatabaseManager {
       })
       const wasmModule = await WebAssembly.compile(wasmResponse.arrayBuffer)
       const vectorExtensionBundlePath = new URL(
-        'https://unpkg.com/@electric-sql/pglite/dist/vector.tar.gz',
+        `https://unpkg.com/@electric-sql/pglite@${PGLITE_VERSION}/dist/vector.tar.gz`,
       )
 
       return { fsBundle, wasmModule, vectorExtensionBundlePath }


### PR DESCRIPTION
The unpinned PGlite version was causing a runtime TypeError where ASM_CONSTS[i] was not a function. This pins the version to 0.2.12 across all PGlite assets (`postgres.data`, `postgres.wasm`, and `vector.tar.gz`) to ensure compatibility and resolve the runtime error.