### PR TITLE
refactor: restructure model configuration and settings

### DIFF
--- a/drizzle/0006_rename_vector_tables.sql
+++ b/drizzle/0006_rename_vector_tables.sql
@@ -1,0 +1,13 @@
+ALTER TABLE "vector_data_text_embedding_3_small" RENAME TO "vector_data_openai_text_embedding_3_small";--> statement-breakpoint
+ALTER TABLE "vector_data_text_embedding_3_large" RENAME TO "vector_data_openai_text_embedding_3_large";--> statement-breakpoint
+ALTER TABLE "vector_data_nomic_embed_text" RENAME TO "vector_data_ollama_nomic_embed_text";--> statement-breakpoint
+ALTER TABLE "vector_data_mxbai_embed_large" RENAME TO "vector_data_ollama_mxbai_embed_large";--> statement-breakpoint
+ALTER TABLE "vector_data_bge_m3" RENAME TO "vector_data_ollama_bge_m3";--> statement-breakpoint
+DROP INDEX IF EXISTS "embeddingIndex_text_embedding_3_small";--> statement-breakpoint
+DROP INDEX IF EXISTS "embeddingIndex_nomic_embed_text";--> statement-breakpoint
+DROP INDEX IF EXISTS "embeddingIndex_mxbai_embed_large";--> statement-breakpoint
+DROP INDEX IF EXISTS "embeddingIndex_bge_m3";--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "embeddingIndex_openai_text_embedding_3_small" ON "vector_data_openai_text_embedding_3_small" USING hnsw ("embedding" vector_cosine_ops);--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "embeddingIndex_ollama_nomic_embed_text" ON "vector_data_ollama_nomic_embed_text" USING hnsw ("embedding" vector_cosine_ops);--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "embeddingIndex_ollama_mxbai_embed_large" ON "vector_data_ollama_mxbai_embed_large" USING hnsw ("embedding" vector_cosine_ops);--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "embeddingIndex_ollama_bge_m3" ON "vector_data_ollama_bge_m3" USING hnsw ("embedding" vector_cosine_ops);

--- a/drizzle/0006_rename_vector_tables.sql
+++ b/drizzle/0006_rename_vector_tables.sql
@@ -3,11 +3,7 @@ ALTER TABLE "vector_data_text_embedding_3_large" RENAME TO "vector_data_openai_t
 ALTER TABLE "vector_data_nomic_embed_text" RENAME TO "vector_data_ollama_nomic_embed_text";--> statement-breakpoint
 ALTER TABLE "vector_data_mxbai_embed_large" RENAME TO "vector_data_ollama_mxbai_embed_large";--> statement-breakpoint
 ALTER TABLE "vector_data_bge_m3" RENAME TO "vector_data_ollama_bge_m3";--> statement-breakpoint
-DROP INDEX IF EXISTS "embeddingIndex_text_embedding_3_small";--> statement-breakpoint
-DROP INDEX IF EXISTS "embeddingIndex_nomic_embed_text";--> statement-breakpoint
-DROP INDEX IF EXISTS "embeddingIndex_mxbai_embed_large";--> statement-breakpoint
-DROP INDEX IF EXISTS "embeddingIndex_bge_m3";--> statement-breakpoint
-CREATE INDEX IF NOT EXISTS "embeddingIndex_openai_text_embedding_3_small" ON "vector_data_openai_text_embedding_3_small" USING hnsw ("embedding" vector_cosine_ops);--> statement-breakpoint
-CREATE INDEX IF NOT EXISTS "embeddingIndex_ollama_nomic_embed_text" ON "vector_data_ollama_nomic_embed_text" USING hnsw ("embedding" vector_cosine_ops);--> statement-breakpoint
-CREATE INDEX IF NOT EXISTS "embeddingIndex_ollama_mxbai_embed_large" ON "vector_data_ollama_mxbai_embed_large" USING hnsw ("embedding" vector_cosine_ops);--> statement-breakpoint
-CREATE INDEX IF NOT EXISTS "embeddingIndex_ollama_bge_m3" ON "vector_data_ollama_bge_m3" USING hnsw ("embedding" vector_cosine_ops);
+ALTER INDEX IF EXISTS "embeddingIndex_text_embedding_3_small" RENAME TO "embeddingIndex_openai_text_embedding_3_small";--> statement-breakpoint
+ALTER INDEX IF EXISTS "embeddingIndex_nomic_embed_text" RENAME TO "embeddingIndex_ollama_nomic_embed_text";--> statement-breakpoint
+ALTER INDEX IF EXISTS "embeddingIndex_mxbai_embed_large" RENAME TO "embeddingIndex_ollama_mxbai_embed_large";--> statement-breakpoint
+ALTER INDEX IF EXISTS "embeddingIndex_bge_m3" RENAME TO "embeddingIndex_ollama_bge_m3";--> statement-breakpoint

--- a/drizzle/meta/0006_snapshot.json
+++ b/drizzle/meta/0006_snapshot.json
@@ -1,0 +1,370 @@
+{
+  "id": "f33fa3e2-3170-4187-a15d-d01ed651fe8b",
+  "prevId": "410315fb-45e8-44ba-91f2-deadeac035d6",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.template": {
+      "name": "template",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "template_name_unique": {
+          "name": "template_name_unique",
+          "nullsNotDistinct": false,
+          "columns": ["name"]
+        }
+      },
+      "checkConstraints": {}
+    },
+    "public.vector_data_openai_text_embedding_3_small": {
+      "name": "vector_data_openai_text_embedding_3_small",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "path": {
+          "name": "path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "mtime": {
+          "name": "mtime",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "embedding": {
+          "name": "embedding",
+          "type": "vector(1536)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "embeddingIndex_openai_text_embedding_3_small": {
+          "name": "embeddingIndex_openai_text_embedding_3_small",
+          "columns": [
+            {
+              "expression": "embedding",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "vector_cosine_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "hnsw",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "public.vector_data_openai_text_embedding_3_large": {
+      "name": "vector_data_openai_text_embedding_3_large",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "path": {
+          "name": "path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "mtime": {
+          "name": "mtime",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "embedding": {
+          "name": "embedding",
+          "type": "vector(3072)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "public.vector_data_ollama_nomic_embed_text": {
+      "name": "vector_data_ollama_nomic_embed_text",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "path": {
+          "name": "path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "mtime": {
+          "name": "mtime",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "embedding": {
+          "name": "embedding",
+          "type": "vector(768)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "embeddingIndex_ollama_nomic_embed_text": {
+          "name": "embeddingIndex_ollama_nomic_embed_text",
+          "columns": [
+            {
+              "expression": "embedding",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "vector_cosine_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "hnsw",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "public.vector_data_ollama_mxbai_embed_large": {
+      "name": "vector_data_ollama_mxbai_embed_large",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "path": {
+          "name": "path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "mtime": {
+          "name": "mtime",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "embedding": {
+          "name": "embedding",
+          "type": "vector(1024)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "embeddingIndex_ollama_mxbai_embed_large": {
+          "name": "embeddingIndex_ollama_mxbai_embed_large",
+          "columns": [
+            {
+              "expression": "embedding",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "vector_cosine_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "hnsw",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "public.vector_data_ollama_bge_m3": {
+      "name": "vector_data_ollama_bge_m3",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "path": {
+          "name": "path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "mtime": {
+          "name": "mtime",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "embedding": {
+          "name": "embedding",
+          "type": "vector(1024)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "embeddingIndex_ollama_bge_m3": {
+          "name": "embeddingIndex_ollama_bge_m3",
+          "columns": [
+            {
+              "expression": "embedding",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "vector_cosine_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "hnsw",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -43,6 +43,13 @@
       "when": 1730443763982,
       "tag": "0005_create_template_table",
       "breakpoints": true
+    },
+    {
+      "idx": 6,
+      "version": "7",
+      "when": 1732064682864,
+      "tag": "0006_rename_vector_tables",
+      "breakpoints": true
     }
   ]
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -37,6 +37,7 @@
         "react-markdown": "^9.0.1",
         "react-syntax-highlighter": "^15.5.0",
         "remark-gfm": "^4.0.0",
+        "semver": "^7.6.3",
         "uuid": "^10.0.0",
         "zod": "^3.23.8"
       },
@@ -49,6 +50,7 @@
         "@types/react": "^18.3.10",
         "@types/react-dom": "^18.3.0",
         "@types/react-syntax-highlighter": "^15.5.13",
+        "@types/semver": "^7.5.8",
         "@types/uuid": "^10.0.0",
         "@typescript-eslint/eslint-plugin": "5.29.0",
         "@typescript-eslint/parser": "5.29.0",
@@ -2814,6 +2816,12 @@
       "resolved": "https://registry.npmjs.org/@types/retry/-/retry-0.12.0.tgz",
       "integrity": "sha512-wWKOClTTiizcZhXnPY4wikVAwmdYHp8q6DmC+EJUzAMsycb7HB32Kh9RN4+0gExjmPmZSAQjgURXIGATPegAvA=="
     },
+    "node_modules/@types/semver": {
+      "version": "7.5.8",
+      "resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.5.8.tgz",
+      "integrity": "sha512-I8EUhyrgfLrcTkzV3TSsGyl1tSuPrEDzr0yd5m90UgNxQkyDXULk3b6MlQqTCpZpNtWe1K0hzclnZkTcLBe2UQ==",
+      "dev": true
+    },
     "node_modules/@types/stack-utils": {
       "version": "2.0.3",
       "dev": true,
@@ -3801,9 +3809,10 @@
       }
     },
     "node_modules/cross-spawn": {
-      "version": "7.0.3",
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "path-key": "^3.1.0",
         "shebang-command": "^2.0.0",
@@ -9904,7 +9913,8 @@
     },
     "node_modules/semver": {
       "version": "7.6.3",
-      "license": "ISC",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.3.tgz",
+      "integrity": "sha512-oVekP1cKtI+CTDvHWYFUcMtsK/00wmAEfyqKfNdARm8u1wNVhSgaX7A8d4UuIlUI5e84iEwOhs7ZPYRmzU9U6A==",
       "bin": {
         "semver": "bin/semver.js"
       },

--- a/package-lock.json
+++ b/package-lock.json
@@ -38,7 +38,6 @@
         "react-markdown": "^9.0.1",
         "react-syntax-highlighter": "^15.5.0",
         "remark-gfm": "^4.0.0",
-        "semver": "^7.6.3",
         "uuid": "^10.0.0",
         "zod": "^3.23.8"
       },

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "@types/react": "^18.3.10",
     "@types/react-dom": "^18.3.0",
     "@types/react-syntax-highlighter": "^15.5.13",
+    "@types/semver": "^7.5.8",
     "@types/uuid": "^10.0.0",
     "@typescript-eslint/eslint-plugin": "5.29.0",
     "@typescript-eslint/parser": "5.29.0",
@@ -72,6 +73,7 @@
     "react-markdown": "^9.0.1",
     "react-syntax-highlighter": "^15.5.0",
     "remark-gfm": "^4.0.0",
+    "semver": "^7.6.3",
     "uuid": "^10.0.0",
     "zod": "^3.23.8"
   }

--- a/package.json
+++ b/package.json
@@ -74,7 +74,6 @@
     "react-markdown": "^9.0.1",
     "react-syntax-highlighter": "^15.5.0",
     "remark-gfm": "^4.0.0",
-    "semver": "^7.6.3",
     "uuid": "^10.0.0",
     "zod": "^3.23.8"
   }

--- a/src/components/chat-view/Chat.tsx
+++ b/src/components/chat-view/Chat.tsx
@@ -22,6 +22,7 @@ import {
   LLMAPIKeyInvalidException,
   LLMAPIKeyNotSetException,
   LLMBaseUrlNotSetException,
+  LLMModelNotSetException,
 } from '../../core/llm/exception'
 import { useChatHistory } from '../../hooks/useChatHistory'
 import { ChatMessage, ChatUserMessage } from '../../types/chat'
@@ -297,7 +298,8 @@ const Chat = forwardRef<ChatRef, ChatProps>((props, ref) => {
       if (
         error instanceof LLMAPIKeyNotSetException ||
         error instanceof LLMAPIKeyInvalidException ||
-        error instanceof LLMBaseUrlNotSetException
+        error instanceof LLMBaseUrlNotSetException ||
+        error instanceof LLMModelNotSetException
       ) {
         openSettingsModalWithError(app, error.message)
       } else {
@@ -356,7 +358,8 @@ const Chat = forwardRef<ChatRef, ChatProps>((props, ref) => {
       if (
         error instanceof LLMAPIKeyNotSetException ||
         error instanceof LLMAPIKeyInvalidException ||
-        error instanceof LLMBaseUrlNotSetException
+        error instanceof LLMBaseUrlNotSetException ||
+        error instanceof LLMModelNotSetException
       ) {
         openSettingsModalWithError(app, error.message)
       } else {

--- a/src/components/chat-view/Chat.tsx
+++ b/src/components/chat-view/Chat.tsx
@@ -82,7 +82,7 @@ const Chat = forwardRef<ChatRef, ChatProps>((props, ref) => {
     getChatMessagesById,
     chatList,
   } = useChatHistory()
-  const { generateResponse, streamResponse } = useLLM()
+  const { generateResponse, streamResponse, chatModel, applyModel } = useLLM()
 
   const promptGenerator = useMemo(() => {
     return new PromptGenerator(getRAGEngine, app, settings)
@@ -257,8 +257,9 @@ const Chat = forwardRef<ChatRef, ChatProps>((props, ref) => {
           { role: 'assistant', content: '', id: responseMessageId },
         ])
         const stream = await streamResponse(
+          chatModel,
           {
-            model: settings.chatModel,
+            model: chatModel.model,
             messages: requestMessages,
             stream: true,
           },
@@ -333,7 +334,7 @@ const Chat = forwardRef<ChatRef, ChatProps>((props, ref) => {
         activeFile,
         activeFileContent,
         chatMessages,
-        settings.applyModel,
+        applyModel,
         generateResponse,
       )
       if (!updatedFileContent) {

--- a/src/components/chat-view/chat-input/ModelSelect.tsx
+++ b/src/components/chat-view/chat-input/ModelSelect.tsx
@@ -12,8 +12,9 @@ export function ModelSelect() {
     <DropdownMenu.Root open={isOpen} onOpenChange={setIsOpen}>
       <DropdownMenu.Trigger className="smtcmp-chat-input-model-select">
         {
-          CHAT_MODEL_OPTIONS.find((model) => model.value === settings.chatModel)
-            ?.name
+          CHAT_MODEL_OPTIONS.find(
+            (option) => option.id === settings.chatModelId,
+          )?.name
         }
         {isOpen ? <ChevronUp size={10} /> : <ChevronDown size={10} />}
       </DropdownMenu.Trigger>
@@ -21,18 +22,18 @@ export function ModelSelect() {
       <DropdownMenu.Portal>
         <DropdownMenu.Content className="smtcmp-popover">
           <ul>
-            {CHAT_MODEL_OPTIONS.map((model) => (
+            {CHAT_MODEL_OPTIONS.map((option) => (
               <DropdownMenu.Item
-                key={model.value}
+                key={option.id}
                 onSelect={() => {
                   setSettings({
                     ...settings,
-                    chatModel: model.value,
+                    chatModelId: option.id,
                   })
                 }}
                 asChild
               >
-                <li>{model.name}</li>
+                <li>{option.name}</li>
               </DropdownMenu.Item>
             ))}
           </ul>

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,77 +1,165 @@
+import { EmbeddingModelOption } from './types/embedding'
+import { ModelOption } from './types/llm/model'
+
 export const CHAT_VIEW_TYPE = 'smtcmp-chat-view'
 export const APPLY_VIEW_TYPE = 'smtcmp-apply-view'
 
-export const CHAT_MODEL_OPTIONS = [
+export const CHAT_MODEL_OPTIONS: ModelOption[] = [
   {
+    id: 'anthropic/claude-3.5-sonnet-latest',
     name: 'claude-3.5-sonnet (Recommended)',
-    value: 'claude-3-5-sonnet-latest',
+    model: {
+      provider: 'anthropic',
+      model: 'claude-3-5-sonnet-latest',
+    },
   },
   {
+    id: 'openai/gpt-4o',
     name: 'gpt-4o',
-    value: 'gpt-4o',
+    model: {
+      provider: 'openai',
+      model: 'gpt-4o',
+    },
   },
   {
+    id: 'openai/gpt-4o-mini',
     name: 'gpt-4o-mini',
-    value: 'gpt-4o-mini',
+    model: {
+      provider: 'openai',
+      model: 'gpt-4o-mini',
+    },
   },
   {
+    id: 'groq/llama-3.1-70b-versatile',
     name: 'llama-3.1-70b (Groq)',
-    value: 'llama-3.1-70b-versatile',
+    model: {
+      provider: 'groq',
+      model: 'llama-3.1-70b-versatile',
+    },
   },
   {
-    name: 'llama3.1:8b (Ollama)',
-    value: 'llama3.1:8b',
+    id: 'ollama',
+    name: 'Ollama',
+    model: {
+      provider: 'ollama',
+      model: '',
+      baseURL: '',
+    },
+  },
+  {
+    id: 'openai-compatible',
+    name: 'Custom (OpenAI Compatible)',
+    model: {
+      provider: 'openai-compatible',
+      model: '',
+      apiKey: '',
+      baseURL: '',
+    },
   },
 ]
 
-export const APPLY_MODEL_OPTIONS = [
+export const APPLY_MODEL_OPTIONS: ModelOption[] = [
   {
+    id: 'openai/gpt-4o-mini',
     name: 'gpt-4o-mini (Recommended)',
-    value: 'gpt-4o-mini',
+    model: {
+      provider: 'openai',
+      model: 'gpt-4o-mini',
+    },
   },
   {
+    id: 'anthropic/claude-3.5-haiku',
+    name: 'claude-3.5-haiku',
+    model: {
+      provider: 'anthropic',
+      model: 'claude-3-5-haiku-latest',
+    },
+  },
+  {
+    id: 'groq/llama-3.1-8b-instant',
     name: 'llama-3.1-8b (Groq)',
-    value: 'llama-3.1-8b-instant',
+    model: {
+      provider: 'groq',
+      model: 'llama-3.1-8b-instant',
+    },
   },
   {
-    name: 'llama3-8b (Groq)',
-    value: 'llama3-8b-8192',
-  },
-  {
+    id: 'groq/llama-3.1-70b-versatile',
     name: 'llama-3.1-70b (Groq)',
-    value: 'llama-3.1-70b-versatile',
+    model: {
+      provider: 'groq',
+      model: 'llama-3.1-70b-versatile',
+    },
   },
   {
-    name: 'llama3.1:8b (Ollama)',
-    value: 'llama3.1:8b',
+    id: 'ollama',
+    name: 'Ollama',
+    model: {
+      provider: 'ollama',
+      model: '',
+      baseURL: '',
+    },
+  },
+  {
+    id: 'openai-compatible',
+    name: 'Custom (OpenAI Compatible)',
+    model: {
+      provider: 'openai-compatible',
+      model: '',
+      apiKey: '',
+      baseURL: '',
+    },
   },
 ]
 
 // Update table exports in src/database/schema.ts when updating this
-export const EMBEDDING_MODEL_OPTIONS = [
+export const EMBEDDING_MODEL_OPTIONS: EmbeddingModelOption[] = [
   {
+    id: 'openai/text-embedding-3-small',
     name: 'text-embedding-3-small (Recommended)',
-    value: 'text-embedding-3-small',
+    model: {
+      provider: 'openai',
+      model: 'text-embedding-3-small',
+    },
     dimension: 1536,
   },
   {
+    id: 'openai/text-embedding-3-large',
     name: 'text-embedding-3-large',
-    value: 'text-embedding-3-large',
+    model: {
+      provider: 'openai',
+      model: 'text-embedding-3-large',
+    },
     dimension: 3072,
   },
   {
     name: 'nomic-embed-text (Ollama)',
-    value: 'nomic-embed-text',
+    id: 'ollama/nomic-embed-text',
+    model: {
+      provider: 'ollama',
+      model: 'nomic-embed-text',
+      baseURL: '',
+    },
     dimension: 768,
   },
   {
     name: 'mxbai-embed-large (Ollama)',
-    value: 'mxbai-embed-large',
+    id: 'ollama/mxbai-embed-large',
+    model: {
+      provider: 'ollama',
+      model: 'mxbai-embed-large',
+      baseURL: '',
+    },
     dimension: 1024,
   },
   {
     name: 'bge-m3 (Ollama)',
-    value: 'bge-m3',
+    id: 'ollama/bge-m3',
+    model: {
+      provider: 'ollama',
+      model: 'bge-m3',
+      baseURL: '',
+    },
     dimension: 1024,
   },
 ]

--- a/src/contexts/llm-context.tsx
+++ b/src/contexts/llm-context.tsx
@@ -4,10 +4,13 @@ import {
   useCallback,
   useContext,
   useEffect,
+  useMemo,
   useState,
 } from 'react'
 
+import { APPLY_MODEL_OPTIONS, CHAT_MODEL_OPTIONS } from '../constants'
 import LLMManager from '../core/llm/manager'
+import { LLMModel } from '../types/llm/model'
 import {
   LLMOptions,
   LLMRequestNonStreaming,
@@ -22,13 +25,17 @@ import { useSettings } from './settings-context'
 
 export type LLMContextType = {
   generateResponse: (
+    model: LLMModel,
     request: LLMRequestNonStreaming,
     options?: LLMOptions,
   ) => Promise<LLMResponseNonStreaming>
   streamResponse: (
+    model: LLMModel,
     request: LLMRequestStreaming,
     options?: LLMOptions,
   ) => Promise<AsyncIterable<LLMResponseStreaming>>
+  chatModel: LLMModel
+  applyModel: LLMModel
 }
 
 const LLMContext = createContext<LLMContextType | null>(null)
@@ -37,45 +44,97 @@ export function LLMProvider({ children }: PropsWithChildren) {
   const [llmManager, setLLMManager] = useState<LLMManager | null>(null)
   const { settings } = useSettings()
 
+  const chatModel = useMemo((): LLMModel => {
+    const model = CHAT_MODEL_OPTIONS.find(
+      (option) => option.id === settings.chatModelId,
+    )?.model
+    if (!model) {
+      throw new Error('Invalid chat model ID')
+    }
+    if (model.provider === 'ollama') {
+      return {
+        provider: 'ollama',
+        baseURL: settings.ollamaChatModel.baseUrl,
+        model: settings.ollamaChatModel.model,
+      }
+    }
+    if (model.provider === 'openai-compatible') {
+      return {
+        provider: 'openai-compatible',
+        baseURL: settings.openAICompatibleChatModel.baseUrl,
+        apiKey: settings.openAICompatibleChatModel.apiKey,
+        model: settings.openAICompatibleChatModel.model,
+      }
+    }
+    return model
+  }, [settings])
+
+  const applyModel = useMemo((): LLMModel => {
+    const model = APPLY_MODEL_OPTIONS.find(
+      (option) => option.id === settings.applyModelId,
+    )?.model
+    if (!model) {
+      throw new Error('Invalid apply model ID')
+    }
+    if (model.provider === 'ollama') {
+      return {
+        provider: 'ollama',
+        baseURL: settings.ollamaApplyModel.baseUrl,
+        model: settings.ollamaApplyModel.model,
+      }
+    }
+    if (model.provider === 'openai-compatible') {
+      return {
+        provider: 'openai-compatible',
+        apiKey: settings.openAICompatibleApplyModel.apiKey,
+        baseURL: settings.openAICompatibleApplyModel.baseUrl,
+        model: settings.openAICompatibleApplyModel.model,
+      }
+    }
+    return model
+  }, [settings])
+
   useEffect(() => {
-    const manager = new LLMManager(
-      {
-        openai: settings.openAIApiKey,
-        groq: settings.groqApiKey,
-        anthropic: settings.anthropicApiKey,
-      },
-      settings.ollamaBaseUrl,
-    )
+    const manager = new LLMManager({
+      openai: settings.openAIApiKey,
+      groq: settings.groqApiKey,
+      anthropic: settings.anthropicApiKey,
+    })
     setLLMManager(manager)
-  }, [
-    settings.openAIApiKey,
-    settings.groqApiKey,
-    settings.anthropicApiKey,
-    settings.ollamaBaseUrl,
-  ])
+  }, [settings.openAIApiKey, settings.groqApiKey, settings.anthropicApiKey])
 
   const generateResponse = useCallback(
-    async (request: LLMRequestNonStreaming, options?: LLMOptions) => {
+    async (
+      model: LLMModel,
+      request: LLMRequestNonStreaming,
+      options?: LLMOptions,
+    ) => {
       if (!llmManager) {
         throw new Error('LLMManager is not initialized')
       }
-      return await llmManager.generateResponse(request, options)
+      return await llmManager.generateResponse(model, request, options)
     },
     [llmManager],
   )
 
   const streamResponse = useCallback(
-    async (request: LLMRequestStreaming, options?: LLMOptions) => {
+    async (
+      model: LLMModel,
+      request: LLMRequestStreaming,
+      options?: LLMOptions,
+    ) => {
       if (!llmManager) {
         throw new Error('LLMManager is not initialized')
       }
-      return await llmManager.streamResponse(request, options)
+      return await llmManager.streamResponse(model, request, options)
     },
     [llmManager],
   )
 
   return (
-    <LLMContext.Provider value={{ generateResponse, streamResponse }}>
+    <LLMContext.Provider
+      value={{ generateResponse, streamResponse, chatModel, applyModel }}
+    >
       {children}
     </LLMContext.Provider>
   )

--- a/src/core/llm/anthropic.ts
+++ b/src/core/llm/anthropic.ts
@@ -4,6 +4,7 @@ import {
   MessageStreamEvent,
 } from '@anthropic-ai/sdk/resources/messages'
 
+import { LLMModel } from '../../types/llm/model'
 import {
   LLMOptions,
   LLMRequestNonStreaming,
@@ -21,9 +22,6 @@ import {
   LLMAPIKeyNotSetException,
 } from './exception'
 
-export type AnthropicModel = 'claude-3-5-sonnet-latest'
-export const ANTHROPIC_MODELS: AnthropicModel[] = ['claude-3-5-sonnet-latest']
-
 export class AnthropicProvider implements BaseLLMProvider {
   private client: Anthropic
 
@@ -32,6 +30,7 @@ export class AnthropicProvider implements BaseLLMProvider {
   }
 
   async generateResponse(
+    model: LLMModel,
     request: LLMRequestNonStreaming,
     options?: LLMOptions,
   ): Promise<LLMResponseNonStreaming> {
@@ -77,6 +76,7 @@ export class AnthropicProvider implements BaseLLMProvider {
   }
 
   async streamResponse(
+    model: LLMModel,
     request: LLMRequestStreaming,
     options?: LLMOptions,
   ): Promise<AsyncIterable<LLMResponseStreaming>> {
@@ -204,9 +204,5 @@ export class AnthropicProvider implements BaseLLMProvider {
       object: 'chat.completion.chunk',
       model: model,
     }
-  }
-
-  getSupportedModels(): string[] {
-    return ANTHROPIC_MODELS
   }
 }

--- a/src/core/llm/base.ts
+++ b/src/core/llm/base.ts
@@ -1,3 +1,4 @@
+import { LLMModel } from '../../types/llm/model'
 import {
   LLMOptions,
   LLMRequestNonStreaming,
@@ -10,12 +11,13 @@ import {
 
 export type BaseLLMProvider = {
   generateResponse(
+    model: LLMModel,
     request: LLMRequestNonStreaming,
     options?: LLMOptions,
   ): Promise<LLMResponseNonStreaming>
   streamResponse(
+    model: LLMModel,
     request: LLMRequestStreaming,
     options?: LLMOptions,
   ): Promise<AsyncIterable<LLMResponseStreaming>>
-  getSupportedModels(): string[]
 }

--- a/src/core/llm/exception.ts
+++ b/src/core/llm/exception.ts
@@ -18,3 +18,10 @@ export class LLMBaseUrlNotSetException extends Error {
     this.name = 'LLMBaseUrlNotSetException'
   }
 }
+
+export class LLMModelNotSetException extends Error {
+  constructor(message: string) {
+    super(message)
+    this.name = 'LLMModelNotSetException'
+  }
+}

--- a/src/core/llm/groq.ts
+++ b/src/core/llm/groq.ts
@@ -5,6 +5,7 @@ import {
   ChatCompletionMessageParam,
 } from 'groq-sdk/resources/chat/completions'
 
+import { LLMModel } from '../../types/llm/model'
 import {
   LLMOptions,
   LLMRequestNonStreaming,
@@ -22,20 +23,6 @@ import {
   LLMAPIKeyNotSetException,
 } from './exception'
 
-export type GroqModel =
-  | 'llama-3.1-8b-instant'
-  | 'llama-3.1-70b-versatile'
-  | 'llama3-8b-8192'
-  | 'llama3-70b-8192'
-  | 'mixtral-8x7b-32768'
-export const GROQ_MODELS: GroqModel[] = [
-  'llama-3.1-8b-instant',
-  'llama-3.1-70b-versatile',
-  'llama3-8b-8192',
-  'llama3-70b-8192',
-  'mixtral-8x7b-32768',
-]
-
 export class GroqProvider implements BaseLLMProvider {
   private client: Groq
 
@@ -47,6 +34,7 @@ export class GroqProvider implements BaseLLMProvider {
   }
 
   async generateResponse(
+    model: LLMModel,
     request: LLMRequestNonStreaming,
     options?: LLMOptions,
   ): Promise<LLMResponseNonStreaming> {
@@ -83,6 +71,7 @@ export class GroqProvider implements BaseLLMProvider {
   }
 
   async streamResponse(
+    model: LLMModel,
     request: LLMRequestStreaming,
     options?: LLMOptions,
   ): Promise<AsyncIterable<LLMResponseStreaming>> {
@@ -171,9 +160,5 @@ export class GroqProvider implements BaseLLMProvider {
       model: chunk.model,
       object: 'chat.completion.chunk',
     }
-  }
-
-  getSupportedModels(): string[] {
-    return GROQ_MODELS
   }
 }

--- a/src/core/llm/ollama.ts
+++ b/src/core/llm/ollama.ts
@@ -18,6 +18,7 @@ import {
 } from '../../types/llm/response'
 
 import { BaseLLMProvider } from './base'
+import { LLMBaseUrlNotSetException } from './exception'
 import { OpenAIMessageAdapter } from './openaiMessageAdapter'
 
 export class NoStainlessOpenAI extends OpenAI {
@@ -56,6 +57,12 @@ export class OllamaProvider implements BaseLLMProvider {
     request: LLMRequestNonStreaming,
     options?: LLMOptions,
   ): Promise<LLMResponseNonStreaming> {
+    if (!model.baseURL) {
+      throw new LLMBaseUrlNotSetException(
+        'Ollama base URL is missing. Please set it in settings menu.',
+      )
+    }
+
     const client = new NoStainlessOpenAI({
       baseURL: `${model.baseURL}/v1`,
       apiKey: '',
@@ -69,6 +76,12 @@ export class OllamaProvider implements BaseLLMProvider {
     request: LLMRequestStreaming,
     options?: LLMOptions,
   ): Promise<AsyncIterable<LLMResponseStreaming>> {
+    if (!model.baseURL) {
+      throw new LLMBaseUrlNotSetException(
+        'Ollama base URL is missing. Please set it in settings menu.',
+      )
+    }
+
     const client = new NoStainlessOpenAI({
       baseURL: `${model.baseURL}/v1`,
       apiKey: '',

--- a/src/core/llm/ollama.ts
+++ b/src/core/llm/ollama.ts
@@ -45,10 +45,10 @@ export class NoStainlessOpenAI extends OpenAI {
 }
 
 export class OllamaProvider implements BaseLLMProvider {
-  private provider: OpenAIMessageAdapter
+  private adapter: OpenAIMessageAdapter
 
   constructor() {
-    this.provider = new OpenAIMessageAdapter()
+    this.adapter = new OpenAIMessageAdapter()
   }
 
   async generateResponse(
@@ -61,7 +61,7 @@ export class OllamaProvider implements BaseLLMProvider {
       apiKey: '',
       dangerouslyAllowBrowser: true,
     })
-    return this.provider.generateResponse(client, request, options)
+    return this.adapter.generateResponse(client, request, options)
   }
 
   async streamResponse(
@@ -74,6 +74,6 @@ export class OllamaProvider implements BaseLLMProvider {
       apiKey: '',
       dangerouslyAllowBrowser: true,
     })
-    return this.provider.streamResponse(client, request, options)
+    return this.adapter.streamResponse(client, request, options)
   }
 }

--- a/src/core/llm/ollama.ts
+++ b/src/core/llm/ollama.ts
@@ -1,6 +1,12 @@
+/**
+ * This provider is nearly identical to OpenAICompatibleProvider, but uses a custom OpenAI client
+ * (NoStainlessOpenAI) to work around CORS issues specific to Ollama.
+ */
+
 import OpenAI from 'openai'
 import { FinalRequestOptions } from 'openai/core'
 
+import { OllamaModel } from '../../types/llm/model'
 import {
   LLMOptions,
   LLMRequestNonStreaming,
@@ -12,8 +18,7 @@ import {
 } from '../../types/llm/response'
 
 import { BaseLLMProvider } from './base'
-import { LLMBaseUrlNotSetException } from './exception'
-import { OpenAICompatibleProvider } from './openaiCompatibleProvider'
+import { OpenAIMessageAdapter } from './openaiMessageAdapter'
 
 export class NoStainlessOpenAI extends OpenAI {
   defaultHeaders() {
@@ -31,6 +36,7 @@ export class NoStainlessOpenAI extends OpenAI {
     const headers = req.req.headers as Record<string, string>
     Object.keys(headers).forEach((k) => {
       if (k.startsWith('x-stainless')) {
+        // eslint-disable-next-line @typescript-eslint/no-dynamic-delete
         delete headers[k]
       }
     })
@@ -38,46 +44,36 @@ export class NoStainlessOpenAI extends OpenAI {
   }
 }
 
-export type OllamaModel = 'llama3.1:8b'
-export const OLLAMA_MODELS: OllamaModel[] = ['llama3.1:8b']
+export class OllamaProvider implements BaseLLMProvider {
+  private provider: OpenAIMessageAdapter
 
-export class OllamaOpenAIProvider implements BaseLLMProvider {
-  private provider: OpenAICompatibleProvider
-  private ollamaBaseUrl: string
-
-  constructor(baseUrl: string) {
-    this.ollamaBaseUrl = baseUrl
-    this.provider = new OpenAICompatibleProvider(
-      new NoStainlessOpenAI({
-        apiKey: '',
-        dangerouslyAllowBrowser: true,
-        baseURL: `${baseUrl}/v1`,
-      }),
-    )
+  constructor() {
+    this.provider = new OpenAIMessageAdapter()
   }
-  generateResponse(
+
+  async generateResponse(
+    model: OllamaModel,
     request: LLMRequestNonStreaming,
     options?: LLMOptions,
   ): Promise<LLMResponseNonStreaming> {
-    if (!this.ollamaBaseUrl) {
-      throw new LLMBaseUrlNotSetException(
-        'Ollama Address is missing. Please set it in settings menu.',
-      )
-    }
-    return this.provider.generateResponse(request, options)
+    const client = new NoStainlessOpenAI({
+      baseURL: `${model.baseURL}/v1`,
+      apiKey: '',
+      dangerouslyAllowBrowser: true,
+    })
+    return this.provider.generateResponse(client, request, options)
   }
-  streamResponse(
+
+  async streamResponse(
+    model: OllamaModel,
     request: LLMRequestStreaming,
     options?: LLMOptions,
   ): Promise<AsyncIterable<LLMResponseStreaming>> {
-    if (!this.ollamaBaseUrl) {
-      throw new LLMBaseUrlNotSetException(
-        'Ollama Address is missing. Please set it in settings menu.',
-      )
-    }
-    return this.provider.streamResponse(request, options)
-  }
-  getSupportedModels(): string[] {
-    return OLLAMA_MODELS
+    const client = new NoStainlessOpenAI({
+      baseURL: `${model.baseURL}/v1`,
+      apiKey: '',
+      dangerouslyAllowBrowser: true,
+    })
+    return this.provider.streamResponse(client, request, options)
   }
 }

--- a/src/core/llm/ollama.ts
+++ b/src/core/llm/ollama.ts
@@ -18,7 +18,7 @@ import {
 } from '../../types/llm/response'
 
 import { BaseLLMProvider } from './base'
-import { LLMBaseUrlNotSetException } from './exception'
+import { LLMBaseUrlNotSetException, LLMModelNotSetException } from './exception'
 import { OpenAIMessageAdapter } from './openaiMessageAdapter'
 
 export class NoStainlessOpenAI extends OpenAI {
@@ -63,6 +63,12 @@ export class OllamaProvider implements BaseLLMProvider {
       )
     }
 
+    if (!model.model) {
+      throw new LLMModelNotSetException(
+        'Ollama model is missing. Please set it in settings menu.',
+      )
+    }
+
     const client = new NoStainlessOpenAI({
       baseURL: `${model.baseURL}/v1`,
       apiKey: '',
@@ -79,6 +85,12 @@ export class OllamaProvider implements BaseLLMProvider {
     if (!model.baseURL) {
       throw new LLMBaseUrlNotSetException(
         'Ollama base URL is missing. Please set it in settings menu.',
+      )
+    }
+
+    if (!model.model) {
+      throw new LLMModelNotSetException(
+        'Ollama model is missing. Please set it in settings menu.',
       )
     }
 

--- a/src/core/llm/openai.ts
+++ b/src/core/llm/openai.ts
@@ -19,12 +19,12 @@ import {
 import { OpenAIMessageAdapter } from './openaiMessageAdapter'
 
 export class OpenAIAuthenticatedProvider implements BaseLLMProvider {
-  private provider: OpenAIMessageAdapter
+  private adapter: OpenAIMessageAdapter
   private client: OpenAI
 
   constructor(apiKey: string) {
     this.client = new OpenAI({ apiKey, dangerouslyAllowBrowser: true })
-    this.provider = new OpenAIMessageAdapter()
+    this.adapter = new OpenAIMessageAdapter()
   }
 
   async generateResponse(
@@ -38,7 +38,7 @@ export class OpenAIAuthenticatedProvider implements BaseLLMProvider {
       )
     }
     try {
-      return this.provider.generateResponse(this.client, request, options)
+      return this.adapter.generateResponse(this.client, request, options)
     } catch (error) {
       if (error instanceof OpenAI.AuthenticationError) {
         throw new LLMAPIKeyInvalidException(
@@ -61,7 +61,7 @@ export class OpenAIAuthenticatedProvider implements BaseLLMProvider {
     }
 
     try {
-      return this.provider.streamResponse(this.client, request, options)
+      return this.adapter.streamResponse(this.client, request, options)
     } catch (error) {
       if (error instanceof OpenAI.AuthenticationError) {
         throw new LLMAPIKeyInvalidException(

--- a/src/core/llm/openaiCompatibleProvider.ts
+++ b/src/core/llm/openaiCompatibleProvider.ts
@@ -12,6 +12,7 @@ import {
 } from '../../types/llm/response'
 
 import { BaseLLMProvider } from './base'
+import { LLMBaseUrlNotSetException } from './exception'
 import { OpenAIMessageAdapter } from './openaiMessageAdapter'
 
 export class OpenAICompatibleProvider implements BaseLLMProvider {
@@ -26,6 +27,12 @@ export class OpenAICompatibleProvider implements BaseLLMProvider {
     request: LLMRequestNonStreaming,
     options?: LLMOptions,
   ): Promise<LLMResponseNonStreaming> {
+    if (!model.baseURL) {
+      throw new LLMBaseUrlNotSetException(
+        'OpenAI Compatible base URL is missing. Please set it in settings menu.',
+      )
+    }
+
     const client = new OpenAI({
       apiKey: model.apiKey,
       baseURL: model.baseURL,
@@ -39,6 +46,12 @@ export class OpenAICompatibleProvider implements BaseLLMProvider {
     request: LLMRequestStreaming,
     options?: LLMOptions,
   ): Promise<AsyncIterable<LLMResponseStreaming>> {
+    if (!model.baseURL) {
+      throw new LLMBaseUrlNotSetException(
+        'OpenAI Compatible base URL is missing. Please set it in settings menu.',
+      )
+    }
+
     const client = new OpenAI({
       apiKey: model.apiKey,
       baseURL: model.baseURL,

--- a/src/core/llm/openaiCompatibleProvider.ts
+++ b/src/core/llm/openaiCompatibleProvider.ts
@@ -15,10 +15,10 @@ import { BaseLLMProvider } from './base'
 import { OpenAIMessageAdapter } from './openaiMessageAdapter'
 
 export class OpenAICompatibleProvider implements BaseLLMProvider {
-  private provider: OpenAIMessageAdapter
+  private adapter: OpenAIMessageAdapter
 
   constructor() {
-    this.provider = new OpenAIMessageAdapter()
+    this.adapter = new OpenAIMessageAdapter()
   }
 
   async generateResponse(
@@ -31,7 +31,7 @@ export class OpenAICompatibleProvider implements BaseLLMProvider {
       baseURL: model.baseURL,
       dangerouslyAllowBrowser: true,
     })
-    return this.provider.generateResponse(client, request, options)
+    return this.adapter.generateResponse(client, request, options)
   }
 
   async streamResponse(
@@ -44,6 +44,6 @@ export class OpenAICompatibleProvider implements BaseLLMProvider {
       baseURL: model.baseURL,
       dangerouslyAllowBrowser: true,
     })
-    return this.provider.streamResponse(client, request, options)
+    return this.adapter.streamResponse(client, request, options)
   }
 }

--- a/src/core/llm/openaiCompatibleProvider.ts
+++ b/src/core/llm/openaiCompatibleProvider.ts
@@ -1,15 +1,10 @@
 import OpenAI from 'openai'
-import {
-  ChatCompletion,
-  ChatCompletionChunk,
-  ChatCompletionMessageParam,
-} from 'openai/resources/chat/completions'
 
+import { OpenAICompatibleModel } from '../../types/llm/model'
 import {
   LLMOptions,
   LLMRequestNonStreaming,
   LLMRequestStreaming,
-  RequestMessage,
 } from '../../types/llm/request'
 import {
   LLMResponseNonStreaming,
@@ -17,121 +12,38 @@ import {
 } from '../../types/llm/response'
 
 import { BaseLLMProvider } from './base'
+import { OpenAIMessageAdapter } from './openaiMessageAdapter'
 
 export class OpenAICompatibleProvider implements BaseLLMProvider {
-  private client: OpenAI
+  private provider: OpenAIMessageAdapter
 
-  constructor(client: OpenAI) {
-    this.client = client
+  constructor() {
+    this.provider = new OpenAIMessageAdapter()
   }
 
   async generateResponse(
+    model: OpenAICompatibleModel,
     request: LLMRequestNonStreaming,
     options?: LLMOptions,
   ): Promise<LLMResponseNonStreaming> {
-    const response = await this.client.chat.completions.create(
-      {
-        model: request.model,
-        messages: request.messages.map((m) =>
-          OpenAICompatibleProvider.parseRequestMessage(m),
-        ),
-        max_tokens: request.max_tokens,
-        temperature: request.temperature,
-        top_p: request.top_p,
-        frequency_penalty: request.frequency_penalty,
-        presence_penalty: request.presence_penalty,
-        logit_bias: request.logit_bias,
-      },
-      {
-        signal: options?.signal,
-      },
-    )
-    return OpenAICompatibleProvider.parseNonStreamingResponse(response)
+    const client = new OpenAI({
+      apiKey: model.apiKey,
+      baseURL: model.baseURL,
+      dangerouslyAllowBrowser: true,
+    })
+    return this.provider.generateResponse(client, request, options)
   }
 
   async streamResponse(
+    model: OpenAICompatibleModel,
     request: LLMRequestStreaming,
     options?: LLMOptions,
   ): Promise<AsyncIterable<LLMResponseStreaming>> {
-    const stream = await this.client.chat.completions.create(
-      {
-        model: request.model,
-        messages: request.messages.map((m) =>
-          OpenAICompatibleProvider.parseRequestMessage(m),
-        ),
-        max_completion_tokens: request.max_tokens,
-        temperature: request.temperature,
-        top_p: request.top_p,
-        frequency_penalty: request.frequency_penalty,
-        presence_penalty: request.presence_penalty,
-        logit_bias: request.logit_bias,
-        stream: true,
-      },
-      {
-        signal: options?.signal,
-      },
-    )
-
-    // eslint-disable-next-line no-inner-declarations
-    async function* streamResponse(): AsyncIterable<LLMResponseStreaming> {
-      for await (const chunk of stream) {
-        yield OpenAICompatibleProvider.parseStreamingResponseChunk(chunk)
-      }
-    }
-
-    return streamResponse()
-  }
-
-  static parseRequestMessage(
-    message: RequestMessage,
-  ): ChatCompletionMessageParam {
-    return {
-      role: message.role,
-      content: message.content,
-    }
-  }
-
-  static parseNonStreamingResponse(
-    response: ChatCompletion,
-  ): LLMResponseNonStreaming {
-    return {
-      id: response.id,
-      choices: response.choices.map((choice) => ({
-        finish_reason: choice.finish_reason,
-        message: {
-          content: choice.message.content,
-          role: choice.message.role,
-        },
-      })),
-      created: response.created,
-      model: response.model,
-      object: 'chat.completion',
-      system_fingerprint: response.system_fingerprint,
-      usage: response.usage,
-    }
-  }
-
-  static parseStreamingResponseChunk(
-    chunk: ChatCompletionChunk,
-  ): LLMResponseStreaming {
-    return {
-      id: chunk.id,
-      choices: chunk.choices.map((choice) => ({
-        finish_reason: choice.finish_reason ?? null,
-        delta: {
-          content: choice.delta.content ?? null,
-          role: choice.delta.role,
-        },
-      })),
-      created: chunk.created,
-      model: chunk.model,
-      object: 'chat.completion.chunk',
-      system_fingerprint: chunk.system_fingerprint,
-      usage: chunk.usage,
-    }
-  }
-
-  getSupportedModels(): string[] {
-    throw new Error('Not implemented')
+    const client = new OpenAI({
+      apiKey: model.apiKey,
+      baseURL: model.baseURL,
+      dangerouslyAllowBrowser: true,
+    })
+    return this.provider.streamResponse(client, request, options)
   }
 }

--- a/src/core/llm/openaiCompatibleProvider.ts
+++ b/src/core/llm/openaiCompatibleProvider.ts
@@ -12,7 +12,7 @@ import {
 } from '../../types/llm/response'
 
 import { BaseLLMProvider } from './base'
-import { LLMBaseUrlNotSetException } from './exception'
+import { LLMBaseUrlNotSetException, LLMModelNotSetException } from './exception'
 import { OpenAIMessageAdapter } from './openaiMessageAdapter'
 
 export class OpenAICompatibleProvider implements BaseLLMProvider {
@@ -33,6 +33,12 @@ export class OpenAICompatibleProvider implements BaseLLMProvider {
       )
     }
 
+    if (!model.model) {
+      throw new LLMModelNotSetException(
+        'OpenAI Compatible model is missing. Please set it in settings menu.',
+      )
+    }
+
     const client = new OpenAI({
       apiKey: model.apiKey,
       baseURL: model.baseURL,
@@ -49,6 +55,12 @@ export class OpenAICompatibleProvider implements BaseLLMProvider {
     if (!model.baseURL) {
       throw new LLMBaseUrlNotSetException(
         'OpenAI Compatible base URL is missing. Please set it in settings menu.',
+      )
+    }
+
+    if (!model.model) {
+      throw new LLMModelNotSetException(
+        'OpenAI Compatible model is missing. Please set it in settings menu.',
       )
     }
 

--- a/src/core/llm/openaiMessageAdapter.ts
+++ b/src/core/llm/openaiMessageAdapter.ts
@@ -1,0 +1,127 @@
+import OpenAI from 'openai'
+import {
+  ChatCompletion,
+  ChatCompletionChunk,
+  ChatCompletionMessageParam,
+} from 'openai/resources/chat/completions'
+
+import {
+  LLMOptions,
+  LLMRequestNonStreaming,
+  LLMRequestStreaming,
+  RequestMessage,
+} from '../../types/llm/request'
+import {
+  LLMResponseNonStreaming,
+  LLMResponseStreaming,
+} from '../../types/llm/response'
+
+export class OpenAIMessageAdapter {
+  async generateResponse(
+    client: OpenAI,
+    request: LLMRequestNonStreaming,
+    options?: LLMOptions,
+  ): Promise<LLMResponseNonStreaming> {
+    const response = await client.chat.completions.create(
+      {
+        model: request.model,
+        messages: request.messages.map((m) =>
+          OpenAIMessageAdapter.parseRequestMessage(m),
+        ),
+        max_tokens: request.max_tokens,
+        temperature: request.temperature,
+        top_p: request.top_p,
+        frequency_penalty: request.frequency_penalty,
+        presence_penalty: request.presence_penalty,
+        logit_bias: request.logit_bias,
+      },
+      {
+        signal: options?.signal,
+      },
+    )
+    return OpenAIMessageAdapter.parseNonStreamingResponse(response)
+  }
+
+  async streamResponse(
+    client: OpenAI,
+    request: LLMRequestStreaming,
+    options?: LLMOptions,
+  ): Promise<AsyncIterable<LLMResponseStreaming>> {
+    const stream = await client.chat.completions.create(
+      {
+        model: request.model,
+        messages: request.messages.map((m) =>
+          OpenAIMessageAdapter.parseRequestMessage(m),
+        ),
+        max_completion_tokens: request.max_tokens,
+        temperature: request.temperature,
+        top_p: request.top_p,
+        frequency_penalty: request.frequency_penalty,
+        presence_penalty: request.presence_penalty,
+        logit_bias: request.logit_bias,
+        stream: true,
+      },
+      {
+        signal: options?.signal,
+      },
+    )
+
+    // eslint-disable-next-line no-inner-declarations
+    async function* streamResponse(): AsyncIterable<LLMResponseStreaming> {
+      for await (const chunk of stream) {
+        yield OpenAIMessageAdapter.parseStreamingResponseChunk(chunk)
+      }
+    }
+
+    return streamResponse()
+  }
+
+  static parseRequestMessage(
+    message: RequestMessage,
+  ): ChatCompletionMessageParam {
+    return {
+      role: message.role,
+      content: message.content,
+    }
+  }
+
+  static parseNonStreamingResponse(
+    response: ChatCompletion,
+  ): LLMResponseNonStreaming {
+    return {
+      id: response.id,
+      choices: response.choices.map((choice) => ({
+        finish_reason: choice.finish_reason,
+        message: {
+          content: choice.message.content,
+          role: choice.message.role,
+        },
+      })),
+      created: response.created,
+      model: response.model,
+      object: 'chat.completion',
+      system_fingerprint: response.system_fingerprint,
+      usage: response.usage,
+    }
+  }
+
+  static parseStreamingResponseChunk(
+    chunk: ChatCompletionChunk,
+  ): LLMResponseStreaming {
+    return {
+      id: chunk.id,
+      choices: chunk.choices.map((choice) => ({
+        finish_reason: choice.finish_reason ?? null,
+        delta: {
+          content: choice.delta.content ?? null,
+          role: choice.delta.role,
+        },
+      })),
+      created: chunk.created,
+      model: chunk.model,
+      object: 'chat.completion.chunk',
+      system_fingerprint: chunk.system_fingerprint,
+      usage: chunk.usage,
+    }
+  }
+}

--- a/src/core/rag/embedding.ts
+++ b/src/core/rag/embedding.ts
@@ -8,20 +8,20 @@ import {
 import { NoStainlessOpenAI } from '../llm/ollama'
 
 export const getEmbeddingModel = (
-  name: string,
+  embeddingModelId: string,
   apiKeys: {
     openAIApiKey: string
   },
   ollamaBaseUrl: string,
 ): EmbeddingModel => {
-  switch (name) {
-    case 'text-embedding-3-small': {
+  switch (embeddingModelId) {
+    case 'openai/text-embedding-3-small': {
       const openai = new OpenAI({
         apiKey: apiKeys.openAIApiKey,
         dangerouslyAllowBrowser: true,
       })
       return {
-        name: 'text-embedding-3-small',
+        id: 'openai/text-embedding-3-small',
         dimension: 1536,
         getEmbedding: async (text: string) => {
           if (!openai.apiKey) {
@@ -37,13 +37,13 @@ export const getEmbeddingModel = (
         },
       }
     }
-    case 'text-embedding-3-large': {
+    case 'openai/text-embedding-3-large': {
       const openai = new OpenAI({
         apiKey: apiKeys.openAIApiKey,
         dangerouslyAllowBrowser: true,
       })
       return {
-        name: 'text-embedding-3-large',
+        id: 'openai/text-embedding-3-large',
         dimension: 3072,
         getEmbedding: async (text: string) => {
           if (!openai.apiKey) {
@@ -59,14 +59,14 @@ export const getEmbeddingModel = (
         },
       }
     }
-    case 'nomic-embed-text': {
+    case 'ollama/nomic-embed-text': {
       const openai = new NoStainlessOpenAI({
         apiKey: '',
         dangerouslyAllowBrowser: true,
         baseURL: `${ollamaBaseUrl}/v1`,
       })
       return {
-        name: 'nomic-embed-text',
+        id: 'ollama/nomic-embed-text',
         dimension: 768,
         getEmbedding: async (text: string) => {
           if (!ollamaBaseUrl) {
@@ -82,14 +82,14 @@ export const getEmbeddingModel = (
         },
       }
     }
-    case 'mxbai-embed-large': {
+    case 'ollama/mxbai-embed-large': {
       const openai = new NoStainlessOpenAI({
         apiKey: '',
         dangerouslyAllowBrowser: true,
         baseURL: `${ollamaBaseUrl}/v1`,
       })
       return {
-        name: 'mxbai-embed-large',
+        id: 'ollama/mxbai-embed-large',
         dimension: 1024,
         getEmbedding: async (text: string) => {
           if (!ollamaBaseUrl) {
@@ -105,14 +105,14 @@ export const getEmbeddingModel = (
         },
       }
     }
-    case 'bge-m3': {
+    case 'ollama/bge-m3': {
       const openai = new NoStainlessOpenAI({
         apiKey: '',
         dangerouslyAllowBrowser: true,
         baseURL: `${ollamaBaseUrl}/v1`,
       })
       return {
-        name: 'bge-m3',
+        id: 'ollama/bge-m3',
         dimension: 1024,
         getEmbedding: async (text: string) => {
           if (!ollamaBaseUrl) {

--- a/src/core/rag/ragEngine.ts
+++ b/src/core/rag/ragEngine.ts
@@ -24,22 +24,22 @@ export class RAGEngine {
     this.settings = settings
     this.vectorManager = dbManager.getVectorManager()
     this.embeddingModel = getEmbeddingModel(
-      settings.embeddingModel,
+      settings.embeddingModelId,
       {
         openAIApiKey: settings.openAIApiKey,
       },
-      settings.ollamaBaseUrl,
+      settings.ollamaEmbeddingModel.baseUrl,
     )
   }
 
   setSettings(settings: SmartCopilotSettings) {
     this.settings = settings
     this.embeddingModel = getEmbeddingModel(
-      settings.embeddingModel,
+      settings.embeddingModelId,
       {
         openAIApiKey: settings.openAIApiKey,
       },
-      settings.ollamaBaseUrl,
+      settings.ollamaEmbeddingModel.baseUrl,
     )
   }
 

--- a/src/database/migrations.json
+++ b/src/database/migrations.json
@@ -59,17 +59,14 @@
       "\nALTER TABLE \"vector_data_nomic_embed_text\" RENAME TO \"vector_data_ollama_nomic_embed_text\";",
       "\nALTER TABLE \"vector_data_mxbai_embed_large\" RENAME TO \"vector_data_ollama_mxbai_embed_large\";",
       "\nALTER TABLE \"vector_data_bge_m3\" RENAME TO \"vector_data_ollama_bge_m3\";",
-      "\nDROP INDEX IF EXISTS \"embeddingIndex_text_embedding_3_small\";",
-      "\nDROP INDEX IF EXISTS \"embeddingIndex_nomic_embed_text\";",
-      "\nDROP INDEX IF EXISTS \"embeddingIndex_mxbai_embed_large\";",
-      "\nDROP INDEX IF EXISTS \"embeddingIndex_bge_m3\";",
-      "\nCREATE INDEX IF NOT EXISTS \"embeddingIndex_openai_text_embedding_3_small\" ON \"vector_data_openai_text_embedding_3_small\" USING hnsw (\"embedding\" vector_cosine_ops);",
-      "\nCREATE INDEX IF NOT EXISTS \"embeddingIndex_ollama_nomic_embed_text\" ON \"vector_data_ollama_nomic_embed_text\" USING hnsw (\"embedding\" vector_cosine_ops);",
-      "\nCREATE INDEX IF NOT EXISTS \"embeddingIndex_ollama_mxbai_embed_large\" ON \"vector_data_ollama_mxbai_embed_large\" USING hnsw (\"embedding\" vector_cosine_ops);",
-      "\nCREATE INDEX IF NOT EXISTS \"embeddingIndex_ollama_bge_m3\" ON \"vector_data_ollama_bge_m3\" USING hnsw (\"embedding\" vector_cosine_ops);"
+      "\nALTER INDEX IF EXISTS \"embeddingIndex_text_embedding_3_small\" RENAME TO \"embeddingIndex_openai_text_embedding_3_small\";",
+      "\nALTER INDEX IF EXISTS \"embeddingIndex_nomic_embed_text\" RENAME TO \"embeddingIndex_ollama_nomic_embed_text\";",
+      "\nALTER INDEX IF EXISTS \"embeddingIndex_mxbai_embed_large\" RENAME TO \"embeddingIndex_ollama_mxbai_embed_large\";",
+      "\nALTER INDEX IF EXISTS \"embeddingIndex_bge_m3\" RENAME TO \"embeddingIndex_ollama_bge_m3\";",
+      ""
     ],
     "bps": true,
     "folderMillis": 1732064682864,
-    "hash": "66ac2fc6f68375dcdbf7c33884bd8a8e5478bb22dd060eecd4efceaed16958b5"
+    "hash": "3dad96e7f1c939c5da3cae4792782e7a35488d39da418e6a9e6f60eafd637f55"
   }
 ]

--- a/src/database/migrations.json
+++ b/src/database/migrations.json
@@ -51,5 +51,25 @@
     "bps": true,
     "folderMillis": 1730443763982,
     "hash": "eddf72b8d40619c170b3c12f3d3ce280385b1fc05717f211ab6077c6bea691bf"
+  },
+  {
+    "sql": [
+      "ALTER TABLE \"vector_data_text_embedding_3_small\" RENAME TO \"vector_data_openai_text_embedding_3_small\";",
+      "\nALTER TABLE \"vector_data_text_embedding_3_large\" RENAME TO \"vector_data_openai_text_embedding_3_large\";",
+      "\nALTER TABLE \"vector_data_nomic_embed_text\" RENAME TO \"vector_data_ollama_nomic_embed_text\";",
+      "\nALTER TABLE \"vector_data_mxbai_embed_large\" RENAME TO \"vector_data_ollama_mxbai_embed_large\";",
+      "\nALTER TABLE \"vector_data_bge_m3\" RENAME TO \"vector_data_ollama_bge_m3\";",
+      "\nDROP INDEX IF EXISTS \"embeddingIndex_text_embedding_3_small\";",
+      "\nDROP INDEX IF EXISTS \"embeddingIndex_nomic_embed_text\";",
+      "\nDROP INDEX IF EXISTS \"embeddingIndex_mxbai_embed_large\";",
+      "\nDROP INDEX IF EXISTS \"embeddingIndex_bge_m3\";",
+      "\nCREATE INDEX IF NOT EXISTS \"embeddingIndex_openai_text_embedding_3_small\" ON \"vector_data_openai_text_embedding_3_small\" USING hnsw (\"embedding\" vector_cosine_ops);",
+      "\nCREATE INDEX IF NOT EXISTS \"embeddingIndex_ollama_nomic_embed_text\" ON \"vector_data_ollama_nomic_embed_text\" USING hnsw (\"embedding\" vector_cosine_ops);",
+      "\nCREATE INDEX IF NOT EXISTS \"embeddingIndex_ollama_mxbai_embed_large\" ON \"vector_data_ollama_mxbai_embed_large\" USING hnsw (\"embedding\" vector_cosine_ops);",
+      "\nCREATE INDEX IF NOT EXISTS \"embeddingIndex_ollama_bge_m3\" ON \"vector_data_ollama_bge_m3\" USING hnsw (\"embedding\" vector_cosine_ops);"
+    ],
+    "bps": true,
+    "folderMillis": 1732064682864,
+    "hash": "66ac2fc6f68375dcdbf7c33884bd8a8e5478bb22dd060eecd4efceaed16958b5"
   }
 ]

--- a/src/database/schema.ts
+++ b/src/database/schema.ts
@@ -12,7 +12,7 @@ import {
 import { SerializedLexicalNode } from 'lexical'
 
 import { EMBEDDING_MODEL_OPTIONS } from '../constants'
-import { EmbeddingModelName } from '../types/embedding'
+import { EmbeddingModelId } from '../types/embedding'
 
 /* Vector Table */
 const createVectorTable = (name: string, dimension: number) => {
@@ -41,27 +41,24 @@ const createVectorTable = (name: string, dimension: number) => {
 export const vectorTables = EMBEDDING_MODEL_OPTIONS.reduce<
   Record<string, ReturnType<typeof createVectorTable>>
 >((acc, modelOption) => {
-  acc[modelOption.value] = createVectorTable(
-    modelOption.value,
-    modelOption.dimension,
-  )
+  acc[modelOption.id] = createVectorTable(modelOption.id, modelOption.dimension)
   return acc
 }, {})
 
-export type VectorTable<M extends EmbeddingModelName> = (typeof vectorTables)[M]
-export type SelectVector = VectorTable<EmbeddingModelName>['$inferSelect']
-export type InsertVector = VectorTable<EmbeddingModelName>['$inferInsert']
+export type VectorTable<M extends EmbeddingModelId> = (typeof vectorTables)[M]
+export type SelectVector = VectorTable<EmbeddingModelId>['$inferSelect']
+export type InsertVector = VectorTable<EmbeddingModelId>['$inferInsert']
 export type VectorMetaData = {
   startLine: number
   endLine: number
 }
 
 // 'npx drizzle-kit generate' requires individual table exports to generate correct migration files
-export const vectorTable0 = vectorTables[EMBEDDING_MODEL_OPTIONS[0].value]
-export const vectorTable1 = vectorTables[EMBEDDING_MODEL_OPTIONS[1].value]
-export const vectorTable2 = vectorTables[EMBEDDING_MODEL_OPTIONS[2].value]
-export const vectorTable3 = vectorTables[EMBEDDING_MODEL_OPTIONS[3].value]
-export const vectorTable4 = vectorTables[EMBEDDING_MODEL_OPTIONS[4].value]
+export const vectorTable0 = vectorTables[EMBEDDING_MODEL_OPTIONS[0].id]
+export const vectorTable1 = vectorTables[EMBEDDING_MODEL_OPTIONS[1].id]
+export const vectorTable2 = vectorTables[EMBEDDING_MODEL_OPTIONS[2].id]
+export const vectorTable3 = vectorTables[EMBEDDING_MODEL_OPTIONS[3].id]
+export const vectorTable4 = vectorTables[EMBEDDING_MODEL_OPTIONS[4].id]
 
 /* Template Table */
 export type TemplateContent = {

--- a/src/types/embedding.ts
+++ b/src/types/embedding.ts
@@ -1,12 +1,21 @@
-export type EmbeddingModelName =
-  | 'text-embedding-3-small'
-  | 'text-embedding-3-large'
-  | 'nomic-embed-text'
-  | 'mxbai-embed-large'
-  | 'bge-m3'
+import { LLMModel } from './llm/model'
+
+export type EmbeddingModelId =
+  | 'openai/text-embedding-3-small'
+  | 'openai/text-embedding-3-large'
+  | 'ollama/nomic-embed-text'
+  | 'ollama/mxbai-embed-large'
+  | 'ollama/bge-m3'
+
+export type EmbeddingModelOption = {
+  id: EmbeddingModelId
+  name: string
+  model: LLMModel
+  dimension: number
+}
 
 export type EmbeddingModel = {
-  name: EmbeddingModelName
+  id: EmbeddingModelId
   dimension: number
   getEmbedding: (text: string) => Promise<number[]>
 }

--- a/src/types/llm/model.ts
+++ b/src/types/llm/model.ts
@@ -1,0 +1,25 @@
+export type NativeLLMModel = {
+  provider: 'openai' | 'anthropic' | 'groq'
+  model: string
+}
+
+export type OllamaModel = {
+  provider: 'ollama'
+  baseURL: string
+  model: string
+}
+
+export type OpenAICompatibleModel = {
+  provider: 'openai-compatible'
+  apiKey: string
+  baseURL: string
+  model: string
+}
+
+export type LLMModel = NativeLLMModel | OllamaModel | OpenAICompatibleModel
+
+export type ModelOption = {
+  id: string
+  name: string
+  model: LLMModel
+}

--- a/src/types/settings.test.ts
+++ b/src/types/settings.test.ts
@@ -5,12 +5,37 @@ describe('parseSmartCopilotSettings', () => {
     const result = parseSmartCopilotSettings({})
     expect(result).toEqual({
       openAIApiKey: '',
-      groqApiKey: '',
       anthropicApiKey: '',
-      ollamaBaseUrl: '',
-      chatModel: 'claude-3-5-sonnet-latest',
-      applyModel: 'gpt-4o-mini',
-      embeddingModel: 'text-embedding-3-small',
+      groqApiKey: '',
+
+      chatModelId: 'anthropic/claude-3.5-sonnet-latest',
+      ollamaChatModel: {
+        baseUrl: '',
+        model: '',
+      },
+      openAICompatibleChatModel: {
+        baseUrl: '',
+        apiKey: '',
+        model: '',
+      },
+
+      applyModelId: 'openai/gpt-4o-mini',
+      ollamaApplyModel: {
+        baseUrl: '',
+        model: '',
+      },
+      openAICompatibleApplyModel: {
+        baseUrl: '',
+        apiKey: '',
+        model: '',
+      },
+
+      embeddingModelId: 'openai/text-embedding-3-small',
+      ollamaEmbeddingModel: {
+        baseUrl: '',
+        model: '',
+      },
+
       systemPrompt: '',
       ragOptions: {
         chunkSize: 1000,

--- a/src/types/settings.test.ts
+++ b/src/types/settings.test.ts
@@ -48,3 +48,69 @@ describe('parseSmartCopilotSettings', () => {
     })
   })
 })
+
+describe('settings migration', () => {
+  it('should migrate from v0.0.0 to v1.0.0', () => {
+    const oldSettings = {
+      openAIApiKey: 'openai-api-key',
+      groqApiKey: 'groq-api-key',
+      anthropicApiKey: 'anthropic-api-key',
+      ollamaBaseUrl: 'http://localhost:11434',
+      chatModel: 'claude-3.5-sonnet-latest',
+      applyModel: 'gpt-4o-mini',
+      embeddingModel: 'text-embedding-3-small',
+      systemPrompt: 'system prompt',
+      ragOptions: {
+        chunkSize: 1000,
+        thresholdTokens: 8192,
+        minSimilarity: 0.0,
+        limit: 10,
+      },
+    }
+
+    const result = parseSmartCopilotSettings(oldSettings)
+    expect(result).toEqual({
+      version: '1.0.0',
+
+      openAIApiKey: 'openai-api-key',
+      groqApiKey: 'groq-api-key',
+      anthropicApiKey: 'anthropic-api-key',
+
+      chatModelId: 'anthropic/claude-3.5-sonnet-latest',
+      ollamaChatModel: {
+        baseUrl: 'http://localhost:11434',
+        model: '',
+      },
+      openAICompatibleChatModel: {
+        baseUrl: '',
+        apiKey: '',
+        model: '',
+      },
+
+      applyModelId: 'openai/gpt-4o-mini',
+      ollamaApplyModel: {
+        baseUrl: 'http://localhost:11434',
+        model: '',
+      },
+      openAICompatibleApplyModel: {
+        baseUrl: '',
+        apiKey: '',
+        model: '',
+      },
+
+      embeddingModelId: 'openai/text-embedding-3-small',
+      ollamaEmbeddingModel: {
+        baseUrl: 'http://localhost:11434',
+        model: '',
+      },
+
+      systemPrompt: 'system prompt',
+      ragOptions: {
+        chunkSize: 1000,
+        thresholdTokens: 8192,
+        minSimilarity: 0.0,
+        limit: 10,
+      },
+    })
+  })
+})

--- a/src/types/settings.test.ts
+++ b/src/types/settings.test.ts
@@ -1,9 +1,11 @@
-import { parseSmartCopilotSettings } from './settings'
+import { SETTINGS_SCHEMA_VERSION, parseSmartCopilotSettings } from './settings'
 
 describe('parseSmartCopilotSettings', () => {
   it('should return default values for empty input', () => {
     const result = parseSmartCopilotSettings({})
     expect(result).toEqual({
+      version: SETTINGS_SCHEMA_VERSION,
+
       openAIApiKey: '',
       anthropicApiKey: '',
       groqApiKey: '',

--- a/src/types/settings.test.ts
+++ b/src/types/settings.test.ts
@@ -51,7 +51,7 @@ describe('parseSmartCopilotSettings', () => {
 })
 
 describe('settings migration', () => {
-  it('should migrate from v0.0.0 to v1.0.0', () => {
+  it('should migrate from v0 to v1', () => {
     const oldSettings = {
       openAIApiKey: 'openai-api-key',
       groqApiKey: 'groq-api-key',
@@ -71,7 +71,7 @@ describe('settings migration', () => {
 
     const result = parseSmartCopilotSettings(oldSettings)
     expect(result).toEqual({
-      version: '1.0.0',
+      version: 1,
 
       openAIApiKey: 'openai-api-key',
       groqApiKey: 'groq-api-key',

--- a/src/types/settings.ts
+++ b/src/types/settings.ts
@@ -1,4 +1,4 @@
-import semver from 'semver'
+import * as semver from 'semver'
 import { z } from 'zod'
 
 import {
@@ -170,7 +170,7 @@ function migrateSettings(
   data: Record<string, unknown>,
 ): Record<string, unknown> {
   let currentData = { ...data }
-  const currentVersion = (currentData.version as string) || '0.0.0'
+  const currentVersion = (currentData.version as string) ?? '0.0.0'
 
   for (const migration of MIGRATIONS) {
     if (

--- a/src/types/settings.ts
+++ b/src/types/settings.ts
@@ -1,3 +1,4 @@
+import semver from 'semver'
 import { z } from 'zod'
 
 import {
@@ -5,6 +6,19 @@ import {
   CHAT_MODEL_OPTIONS,
   EMBEDDING_MODEL_OPTIONS,
 } from '../constants'
+
+export const SETTINGS_SCHEMA_VERSION = '1.0.0'
+
+const ollamaModelSchema = z.object({
+  baseUrl: z.string().catch(''),
+  model: z.string().catch(''),
+})
+
+const openAICompatibleModelSchema = z.object({
+  baseUrl: z.string().catch(''),
+  apiKey: z.string().catch(''),
+  model: z.string().catch(''),
+})
 
 const chatModelIdSchema = z.enum(
   CHAT_MODEL_OPTIONS.map((opt) => opt.id) as [string, ...string[]],
@@ -15,22 +29,24 @@ const applyModelIdSchema = z.enum(
 const embeddingModelIdSchema = z.enum(
   EMBEDDING_MODEL_OPTIONS.map((opt) => opt.id) as [string, ...string[]],
 )
-const ollamaModelSchema = z.object({
-  baseUrl: z.string().catch(''),
-  model: z.string().catch(''),
-})
-const openAICompatibleModelSchema = z.object({
-  baseUrl: z.string().catch(''),
-  apiKey: z.string().catch(''),
-  model: z.string().catch(''),
+
+const ragOptionsSchema = z.object({
+  chunkSize: z.number().catch(1000),
+  thresholdTokens: z.number().catch(8192),
+  minSimilarity: z.number().catch(0.0),
+  limit: z.number().catch(10),
 })
 
-// Update settings.test.ts after changing this schema
 const smartCopilotSettingsSchema = z.object({
+  // Version
+  version: z.literal(SETTINGS_SCHEMA_VERSION).catch(SETTINGS_SCHEMA_VERSION),
+
+  // API Keys
   openAIApiKey: z.string().catch(''),
   anthropicApiKey: z.string().catch(''),
   groqApiKey: z.string().catch(''),
 
+  // Chat Models
   chatModelId: chatModelIdSchema.catch('anthropic/claude-3.5-sonnet-latest'),
   ollamaChatModel: ollamaModelSchema.catch({
     baseUrl: '',
@@ -42,6 +58,7 @@ const smartCopilotSettingsSchema = z.object({
     model: '',
   }),
 
+  // Apply Models
   applyModelId: applyModelIdSchema.catch('openai/gpt-4o-mini'),
   ollamaApplyModel: ollamaModelSchema.catch({
     baseUrl: '',
@@ -53,6 +70,7 @@ const smartCopilotSettingsSchema = z.object({
     model: '',
   }),
 
+  // Embedding Models
   embeddingModelId: embeddingModelIdSchema.catch(
     'openai/text-embedding-3-small',
   ),
@@ -61,27 +79,119 @@ const smartCopilotSettingsSchema = z.object({
     model: '',
   }),
 
+  // System Prompt
   systemPrompt: z.string().catch(''),
-  ragOptions: z
-    .object({
-      chunkSize: z.number().catch(1000),
-      thresholdTokens: z.number().catch(8192),
-      minSimilarity: z.number().catch(0.0),
-      limit: z.number().catch(10),
-    })
-    .catch({
-      chunkSize: 1000,
-      thresholdTokens: 8192,
-      minSimilarity: 0.0,
-      limit: 10,
-    }),
+
+  // RAG Options
+  ragOptions: ragOptionsSchema.catch({
+    chunkSize: 1000,
+    thresholdTokens: 8192,
+    minSimilarity: 0.0,
+    limit: 10,
+  }),
 })
 
 export type SmartCopilotSettings = z.infer<typeof smartCopilotSettingsSchema>
 
+type Migration = {
+  fromVersion: string
+  toVersion: string
+  migrate: (data: Record<string, unknown>) => Record<string, unknown>
+}
+
+const MIGRATIONS: Migration[] = [
+  {
+    fromVersion: '0.0.0',
+    toVersion: '1.0.0',
+    migrate: (data) => {
+      const newData = { ...data }
+
+      if ('chatModel' in newData && typeof newData.chatModel === 'string') {
+        const CHAT_MODEL_MAP: Record<string, string> = {
+          'claude-3.5-sonnet-latest': 'anthropic/claude-3.5-sonnet-latest',
+          'gpt-4o': 'openai/gpt-4o',
+          'gpt-4o-mini': 'openai/gpt-4o-mini',
+          'llama-3.1-70b-versatile': 'groq/llama-3.1-70b-versatile',
+          'llama3.1:8b': 'ollama',
+        }
+        newData.chatModelId = CHAT_MODEL_MAP[newData.chatModel] ?? ''
+        delete newData.chatModel
+      }
+      if ('applyModel' in newData && typeof newData.applyModel === 'string') {
+        const APPLY_MODEL_MAP: Record<string, string> = {
+          'gpt-4o-mini': 'openai/gpt-4o-mini',
+          'llama-3.1-8b-instant': 'groq/llama-3.1-8b-instant',
+          'llama-3.1-70b-versatile': 'groq/llama-3.1-70b-versatile',
+          'llama3.1:8b': 'ollama',
+        }
+        newData.applyModelId = APPLY_MODEL_MAP[newData.applyModel] ?? ''
+        delete newData.applyModel
+      }
+      if (
+        'embeddingModel' in newData &&
+        typeof newData.embeddingModel === 'string'
+      ) {
+        const EMBEDDING_MODEL_MAP: Record<string, string> = {
+          'text-embedding-3-small': 'openai/text-embedding-3-small',
+          'text-embedding-3-large': 'openai/text-embedding-3-large',
+          'nomic-embed-text': 'ollama/nomic-embed-text',
+          'mxbai-embed-large': 'ollama/mxbai-embed-large',
+          'bge-m3': 'ollama/bge-m3',
+        }
+        newData.embeddingModelId =
+          EMBEDDING_MODEL_MAP[newData.embeddingModel] ?? ''
+        delete newData.embeddingModel
+      }
+      if (
+        'ollamaBaseUrl' in newData &&
+        typeof newData.ollamaBaseUrl === 'string'
+      ) {
+        newData.ollamaChatModel = {
+          baseUrl: newData.ollamaBaseUrl,
+          model: '',
+        }
+        newData.ollamaApplyModel = {
+          baseUrl: newData.ollamaBaseUrl,
+          model: '',
+        }
+        newData.ollamaEmbeddingModel = {
+          baseUrl: newData.ollamaBaseUrl,
+          model: '',
+        }
+        delete newData.ollamaBaseUrl
+      }
+
+      return newData
+    },
+  },
+]
+
+function migrateSettings(
+  data: Record<string, unknown>,
+): Record<string, unknown> {
+  let currentData = { ...data }
+  const currentVersion = (currentData.version as string) || '0.0.0'
+
+  for (const migration of MIGRATIONS) {
+    if (
+      semver.gte(currentVersion, migration.fromVersion) &&
+      semver.lt(currentVersion, migration.toVersion) &&
+      semver.lte(migration.toVersion, SETTINGS_SCHEMA_VERSION)
+    ) {
+      console.log(
+        `Migrating settings from ${migration.fromVersion} to ${migration.toVersion}`,
+      )
+      currentData = migration.migrate(currentData)
+    }
+  }
+
+  return currentData
+}
+
 export function parseSmartCopilotSettings(data: unknown): SmartCopilotSettings {
   try {
-    return smartCopilotSettingsSchema.parse(data)
+    const migratedData = migrateSettings(data as Record<string, unknown>)
+    return smartCopilotSettingsSchema.parse(migratedData)
   } catch (error) {
     console.warn('Invalid settings provided, using defaults:', error)
     return smartCopilotSettingsSchema.parse({})

--- a/src/types/settings.ts
+++ b/src/types/settings.ts
@@ -6,25 +6,61 @@ import {
   EMBEDDING_MODEL_OPTIONS,
 } from '../constants'
 
-const chatModelSchema = z.enum(
-  CHAT_MODEL_OPTIONS.map((opt) => opt.value) as [string, ...string[]],
+const chatModelIdSchema = z.enum(
+  CHAT_MODEL_OPTIONS.map((opt) => opt.id) as [string, ...string[]],
 )
-const applyModelSchema = z.enum(
-  APPLY_MODEL_OPTIONS.map((opt) => opt.value) as [string, ...string[]],
+const applyModelIdSchema = z.enum(
+  APPLY_MODEL_OPTIONS.map((opt) => opt.id) as [string, ...string[]],
 )
-const embeddingModelSchema = z.enum(
-  EMBEDDING_MODEL_OPTIONS.map((opt) => opt.value) as [string, ...string[]],
+const embeddingModelIdSchema = z.enum(
+  EMBEDDING_MODEL_OPTIONS.map((opt) => opt.id) as [string, ...string[]],
 )
+const ollamaModelSchema = z.object({
+  baseUrl: z.string().catch(''),
+  model: z.string().catch(''),
+})
+const openAICompatibleModelSchema = z.object({
+  baseUrl: z.string().catch(''),
+  apiKey: z.string().catch(''),
+  model: z.string().catch(''),
+})
 
 // Update settings.test.ts after changing this schema
 const smartCopilotSettingsSchema = z.object({
   openAIApiKey: z.string().catch(''),
-  groqApiKey: z.string().catch(''),
   anthropicApiKey: z.string().catch(''),
-  ollamaBaseUrl: z.string().catch(''),
-  chatModel: chatModelSchema.catch('claude-3-5-sonnet-latest'),
-  applyModel: applyModelSchema.catch('gpt-4o-mini'),
-  embeddingModel: embeddingModelSchema.catch('text-embedding-3-small'),
+  groqApiKey: z.string().catch(''),
+
+  chatModelId: chatModelIdSchema.catch('anthropic/claude-3.5-sonnet-latest'),
+  ollamaChatModel: ollamaModelSchema.catch({
+    baseUrl: '',
+    model: '',
+  }),
+  openAICompatibleChatModel: openAICompatibleModelSchema.catch({
+    baseUrl: '',
+    apiKey: '',
+    model: '',
+  }),
+
+  applyModelId: applyModelIdSchema.catch('openai/gpt-4o-mini'),
+  ollamaApplyModel: ollamaModelSchema.catch({
+    baseUrl: '',
+    model: '',
+  }),
+  openAICompatibleApplyModel: openAICompatibleModelSchema.catch({
+    baseUrl: '',
+    apiKey: '',
+    model: '',
+  }),
+
+  embeddingModelId: embeddingModelIdSchema.catch(
+    'openai/text-embedding-3-small',
+  ),
+  ollamaEmbeddingModel: ollamaModelSchema.catch({
+    baseUrl: '',
+    model: '',
+  }),
+
   systemPrompt: z.string().catch(''),
   ragOptions: z
     .object({

--- a/src/utils/apply.ts
+++ b/src/utils/apply.ts
@@ -3,6 +3,7 @@ import { TFile } from 'obsidian'
 import { editorStateToPlainText } from '../components/chat-view/chat-input/utils/editor-state-to-plain-text'
 import { LLMContextType } from '../contexts/llm-context'
 import { ChatMessage, ChatUserMessage } from '../types/chat'
+import { LLMModel } from '../types/llm/model'
 import { RequestMessage } from '../types/llm/request'
 import { MentionableBlock, MentionableFile } from '../types/mentionable'
 
@@ -84,7 +85,7 @@ export const applyChangesToFile = async (
   currentFile: TFile,
   currentFileContent: string,
   chatMessages: ChatMessage[],
-  model: string,
+  applyModel: LLMModel,
   generateResponse: LLMContextType['generateResponse'],
 ): Promise<string | null> => {
   const requestMessages: RequestMessage[] = [
@@ -103,8 +104,8 @@ export const applyChangesToFile = async (
     },
   ]
 
-  const response = await generateResponse({
-    model,
+  const response = await generateResponse(applyModel, {
+    model: applyModel.model,
     messages: requestMessages,
     stream: false,
   })

--- a/styles.css
+++ b/styles.css
@@ -742,7 +742,7 @@ button.smtcmp-chat-input-model-select {
   }
 }
 
-.smtcmp-setting-textarea {
+.smtcmp-settings-textarea {
   display: block;
   border-top: none;
   padding: 0;
@@ -755,6 +755,22 @@ button.smtcmp-chat-input-model-select {
     width: 100%;
     min-height: 100px;
     resize: none;
+  }
+}
+
+.smtcmp-settings-model-container {
+  margin: var(--size-4-2) 0;
+  padding: var(--size-4-2) var(--size-4-4);
+  border-left: 2px solid var(--interactive-accent);
+  background-color: var(--background-secondary);
+  border-radius: var(--radius-s);
+
+  .setting-item {
+    border-top: none;
+
+    &:first-child {
+      margin-top: var(--size-4-2);
+    }
   }
 }
 


### PR DESCRIPTION
- Introduce new model configuration system with provider-specific settings
- Add support for Ollama and OpenAI-compatible services
- Reorganize model IDs to include provider prefix (e.g. openai/, anthropic/, groq/)
- Update settings UI to show provider-specific configuration fields
- Refactor LLM manager and providers to use new model configuration
- Rename vector tables to match new model ID format
- Add migration for vector table renaming
- Model updates
  - Add `claude-3.5-haiku` option for apply model
  - Remove `llama3-8b (Groq)` option for apply model