### PR TITLE
feat: add image support in chat

### DIFF
--- a/src/components/chat-view/chat-input/ChatUserInput.tsx
+++ b/src/components/chat-view/chat-input/ChatUserInput.tsx
@@ -273,8 +273,10 @@ const ChatUserInput = forwardRef<ChatUserInputRef, ChatUserInputProps>(
         />
 
         <div className="smtcmp-chat-user-input-controls">
-          <ModelSelect />
-          <div className="smtcmp-chat-user-input-controls-buttons">
+          <div className="smtcmp-chat-user-input-controls__model-select-container">
+            <ModelSelect />
+          </div>
+          <div className="smtcmp-chat-user-input-controls__buttons">
             <ImageUploadButton onUpload={handleUploadImages} />
             <SubmitButton onClick={() => handleSubmit()} />
             <VaultChatButton

--- a/src/components/chat-view/chat-input/ImageUploadButton.tsx
+++ b/src/components/chat-view/chat-input/ImageUploadButton.tsx
@@ -1,0 +1,30 @@
+import { ImageIcon } from 'lucide-react'
+
+export function ImageUploadButton({
+  onUpload,
+}: {
+  onUpload: (files: File[]) => void
+}) {
+  const handleFileChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+    const files = Array.from(event.target.files ?? [])
+    if (files.length > 0) {
+      onUpload(files)
+    }
+  }
+
+  return (
+    <label className="smtcmp-chat-user-input-submit-button">
+      <input
+        type="file"
+        accept="image/*"
+        multiple
+        onChange={handleFileChange}
+        style={{ display: 'none' }}
+      />
+      <div className="smtcmp-chat-user-input-submit-button-icons">
+        <ImageIcon size={12} />
+      </div>
+      <div>Image</div>
+    </label>
+  )
+}

--- a/src/components/chat-view/chat-input/LexicalContentEditable.tsx
+++ b/src/components/chat-view/chat-input/LexicalContentEditable.tsx
@@ -35,7 +35,7 @@ export type LexicalContentEditableProps = {
   onEnter?: (evt: KeyboardEvent) => void
   onFocus?: () => void
   onMentionNodeMutation?: (mutations: NodeMutations<MentionNode>) => void
-  onCreateImageMentionable?: (mentionable: MentionableImage) => void
+  onCreateImageMentionables?: (mentionables: MentionableImage[]) => void
   initialEditorState?: InitialEditorStateType
   autoFocus?: boolean
   plugins?: {
@@ -55,7 +55,7 @@ export default function LexicalContentEditable({
   onEnter,
   onFocus,
   onMentionNodeMutation,
-  onCreateImageMentionable,
+  onCreateImageMentionables,
   initialEditorState,
   autoFocus = false,
   plugins,
@@ -138,7 +138,7 @@ export default function LexicalContentEditable({
       <EditorRefPlugin editorRef={editorRef} />
       <NoFormatPlugin />
       <AutoLinkMentionPlugin />
-      <ImagePastePlugin onCreateImageMentionable={onCreateImageMentionable} />
+      <ImagePastePlugin onCreateImageMentionables={onCreateImageMentionables} />
       <TemplatePlugin />
       {plugins?.templatePopover && (
         <CreateTemplatePopoverPlugin

--- a/src/components/chat-view/chat-input/LexicalContentEditable.tsx
+++ b/src/components/chat-view/chat-input/LexicalContentEditable.tsx
@@ -16,6 +16,7 @@ import { useApp } from '../../../contexts/app-context'
 import { MentionableImage } from '../../../types/mentionable'
 import { fuzzySearch } from '../../../utils/fuzzy-search'
 
+import DragDropPaste from './plugins/image/DragDropPastePlugin'
 import ImagePastePlugin from './plugins/image/ImagePastePlugin'
 import AutoLinkMentionPlugin from './plugins/mention/AutoLinkMentionPlugin'
 import { MentionNode } from './plugins/mention/MentionNode'
@@ -139,6 +140,7 @@ export default function LexicalContentEditable({
       <NoFormatPlugin />
       <AutoLinkMentionPlugin />
       <ImagePastePlugin onCreateImageMentionables={onCreateImageMentionables} />
+      <DragDropPaste onCreateImageMentionables={onCreateImageMentionables} />
       <TemplatePlugin />
       {plugins?.templatePopover && (
         <CreateTemplatePopoverPlugin

--- a/src/components/chat-view/chat-input/LexicalContentEditable.tsx
+++ b/src/components/chat-view/chat-input/LexicalContentEditable.tsx
@@ -13,8 +13,10 @@ import { LexicalEditor, SerializedEditorState } from 'lexical'
 import { RefObject, useCallback, useEffect } from 'react'
 
 import { useApp } from '../../../contexts/app-context'
+import { MentionableImage } from '../../../types/mentionable'
 import { fuzzySearch } from '../../../utils/fuzzy-search'
 
+import ImagePastePlugin from './plugins/image/ImagePastePlugin'
 import AutoLinkMentionPlugin from './plugins/mention/AutoLinkMentionPlugin'
 import { MentionNode } from './plugins/mention/MentionNode'
 import MentionPlugin from './plugins/mention/MentionPlugin'
@@ -33,6 +35,7 @@ export type LexicalContentEditableProps = {
   onEnter?: (evt: KeyboardEvent) => void
   onFocus?: () => void
   onMentionNodeMutation?: (mutations: NodeMutations<MentionNode>) => void
+  onCreateImageMentionable?: (mentionable: MentionableImage) => void
   initialEditorState?: InitialEditorStateType
   autoFocus?: boolean
   plugins?: {
@@ -52,6 +55,7 @@ export default function LexicalContentEditable({
   onEnter,
   onFocus,
   onMentionNodeMutation,
+  onCreateImageMentionable,
   initialEditorState,
   autoFocus = false,
   plugins,
@@ -134,6 +138,7 @@ export default function LexicalContentEditable({
       <EditorRefPlugin editorRef={editorRef} />
       <NoFormatPlugin />
       <AutoLinkMentionPlugin />
+      <ImagePastePlugin onCreateImageMentionable={onCreateImageMentionable} />
       <TemplatePlugin />
       {plugins?.templatePopover && (
         <CreateTemplatePopoverPlugin

--- a/src/components/chat-view/chat-input/MentionableBadge.tsx
+++ b/src/components/chat-view/chat-input/MentionableBadge.tsx
@@ -7,6 +7,7 @@ import {
   MentionableCurrentFile,
   MentionableFile,
   MentionableFolder,
+  MentionableImage,
   MentionableUrl,
   MentionableVault,
 } from '../../../types/mentionable'
@@ -17,12 +18,17 @@ function BadgeBase({
   children,
   onDelete,
   onClick,
+  isFocused,
 }: PropsWithChildren<{
   onDelete: () => void
   onClick: () => void
+  isFocused: boolean
 }>) {
   return (
-    <div className="smtcmp-chat-user-input-file-badge" onClick={onClick}>
+    <div
+      className={`smtcmp-chat-user-input-file-badge ${isFocused ? 'smtcmp-chat-user-input-file-badge-focused' : ''}`}
+      onClick={onClick}
+    >
       {children}
       <div
         className="smtcmp-chat-user-input-file-badge-delete"
@@ -41,14 +47,16 @@ function FileBadge({
   mentionable,
   onDelete,
   onClick,
+  isFocused,
 }: {
   mentionable: MentionableFile
   onDelete: () => void
   onClick: () => void
+  isFocused: boolean
 }) {
   const Icon = getMentionableIcon(mentionable)
   return (
-    <BadgeBase onDelete={onDelete} onClick={onClick}>
+    <BadgeBase onDelete={onDelete} onClick={onClick} isFocused={isFocused}>
       <div className="smtcmp-chat-user-input-file-badge-name">
         {Icon && (
           <Icon
@@ -66,15 +74,16 @@ function FolderBadge({
   mentionable,
   onDelete,
   onClick,
+  isFocused,
 }: {
   mentionable: MentionableFolder
   onDelete: () => void
   onClick: () => void
+  isFocused: boolean
 }) {
   const Icon = getMentionableIcon(mentionable)
   return (
-    <BadgeBase onDelete={onDelete} onClick={onClick}>
-      {/* TODO: Update style */}
+    <BadgeBase onDelete={onDelete} onClick={onClick} isFocused={isFocused}>
       <div className="smtcmp-chat-user-input-file-badge-name">
         {Icon && (
           <Icon
@@ -93,14 +102,16 @@ function VaultBadge({
   mentionable,
   onDelete,
   onClick,
+  isFocused,
 }: {
   mentionable: MentionableVault
   onDelete: () => void
   onClick: () => void
+  isFocused: boolean
 }) {
   const Icon = getMentionableIcon(mentionable)
   return (
-    <BadgeBase onDelete={onDelete} onClick={onClick}>
+    <BadgeBase onDelete={onDelete} onClick={onClick} isFocused={isFocused}>
       {/* TODO: Update style */}
       <div className="smtcmp-chat-user-input-file-badge-name">
         {Icon && (
@@ -119,14 +130,16 @@ function CurrentFileBadge({
   mentionable,
   onDelete,
   onClick,
+  isFocused,
 }: {
   mentionable: MentionableCurrentFile
   onDelete: () => void
   onClick: () => void
+  isFocused: boolean
 }) {
   const Icon = getMentionableIcon(mentionable)
   return mentionable.file ? (
-    <BadgeBase onDelete={onDelete} onClick={onClick}>
+    <BadgeBase onDelete={onDelete} onClick={onClick} isFocused={isFocused}>
       <div className="smtcmp-chat-user-input-file-badge-name">
         {Icon && (
           <Icon
@@ -147,14 +160,16 @@ function BlockBadge({
   mentionable,
   onDelete,
   onClick,
+  isFocused,
 }: {
   mentionable: MentionableBlock
   onDelete: () => void
   onClick: () => void
+  isFocused: boolean
 }) {
   const Icon = getMentionableIcon(mentionable)
   return (
-    <BadgeBase onDelete={onDelete} onClick={onClick}>
+    <BadgeBase onDelete={onDelete} onClick={onClick} isFocused={isFocused}>
       <div className="smtcmp-chat-user-input-file-badge-name-block-name">
         {Icon && (
           <Icon
@@ -175,14 +190,16 @@ function UrlBadge({
   mentionable,
   onDelete,
   onClick,
+  isFocused,
 }: {
   mentionable: MentionableUrl
   onDelete: () => void
   onClick: () => void
+  isFocused: boolean
 }) {
   const Icon = getMentionableIcon(mentionable)
   return (
-    <BadgeBase onDelete={onDelete} onClick={onClick}>
+    <BadgeBase onDelete={onDelete} onClick={onClick} isFocused={isFocused}>
       <div className="smtcmp-chat-user-input-file-badge-name">
         {Icon && (
           <Icon
@@ -196,14 +213,43 @@ function UrlBadge({
   )
 }
 
+function ImageBadge({
+  mentionable,
+  onDelete,
+  onClick,
+  isFocused,
+}: {
+  mentionable: MentionableImage
+  onDelete: () => void
+  onClick: () => void
+  isFocused: boolean
+}) {
+  const Icon = getMentionableIcon(mentionable)
+  return (
+    <BadgeBase onDelete={onDelete} onClick={onClick} isFocused={isFocused}>
+      <div className="smtcmp-chat-user-input-file-badge-name">
+        {Icon && (
+          <Icon
+            size={10}
+            className="smtcmp-chat-user-input-file-badge-name-icon"
+          />
+        )}
+        <span>{mentionable.name}</span>
+      </div>
+    </BadgeBase>
+  )
+}
+
 export default function MentionableBadge({
   mentionable,
   onDelete,
   onClick,
+  isFocused = false,
 }: {
   mentionable: Mentionable
   onDelete: () => void
   onClick: () => void
+  isFocused?: boolean
 }) {
   switch (mentionable.type) {
     case 'file':
@@ -212,6 +258,7 @@ export default function MentionableBadge({
           mentionable={mentionable}
           onDelete={onDelete}
           onClick={onClick}
+          isFocused={isFocused}
         />
       )
     case 'folder':
@@ -220,6 +267,7 @@ export default function MentionableBadge({
           mentionable={mentionable}
           onDelete={onDelete}
           onClick={onClick}
+          isFocused={isFocused}
         />
       )
     case 'vault':
@@ -228,6 +276,7 @@ export default function MentionableBadge({
           mentionable={mentionable}
           onDelete={onDelete}
           onClick={onClick}
+          isFocused={isFocused}
         />
       )
     case 'current-file':
@@ -236,6 +285,7 @@ export default function MentionableBadge({
           mentionable={mentionable}
           onDelete={onDelete}
           onClick={onClick}
+          isFocused={isFocused}
         />
       )
     case 'block':
@@ -244,6 +294,7 @@ export default function MentionableBadge({
           mentionable={mentionable}
           onDelete={onDelete}
           onClick={onClick}
+          isFocused={isFocused}
         />
       )
     case 'url':
@@ -252,6 +303,16 @@ export default function MentionableBadge({
           mentionable={mentionable}
           onDelete={onDelete}
           onClick={onClick}
+          isFocused={isFocused}
+        />
+      )
+    case 'image':
+      return (
+        <ImageBadge
+          mentionable={mentionable}
+          onDelete={onDelete}
+          onClick={onClick}
+          isFocused={isFocused}
         />
       )
   }

--- a/src/components/chat-view/chat-input/ModelSelect.tsx
+++ b/src/components/chat-view/chat-input/ModelSelect.tsx
@@ -11,12 +11,16 @@ export function ModelSelect() {
   return (
     <DropdownMenu.Root open={isOpen} onOpenChange={setIsOpen}>
       <DropdownMenu.Trigger className="smtcmp-chat-input-model-select">
-        {
-          CHAT_MODEL_OPTIONS.find(
-            (option) => option.id === settings.chatModelId,
-          )?.name
-        }
-        {isOpen ? <ChevronUp size={10} /> : <ChevronDown size={10} />}
+        <div className="smtcmp-chat-input-model-select__model-name">
+          {
+            CHAT_MODEL_OPTIONS.find(
+              (option) => option.id === settings.chatModelId,
+            )?.name
+          }
+        </div>
+        <div className="smtcmp-chat-input-model-select__icon">
+          {isOpen ? <ChevronUp size={10} /> : <ChevronDown size={10} />}
+        </div>
       </DropdownMenu.Trigger>
 
       <DropdownMenu.Portal>

--- a/src/components/chat-view/chat-input/plugins/image/DragDropPastePlugin.tsx
+++ b/src/components/chat-view/chat-input/plugins/image/DragDropPastePlugin.tsx
@@ -1,0 +1,34 @@
+import { useLexicalComposerContext } from '@lexical/react/LexicalComposerContext'
+import { DRAG_DROP_PASTE } from '@lexical/rich-text'
+import { COMMAND_PRIORITY_LOW } from 'lexical'
+import { useEffect } from 'react'
+
+import { MentionableImage } from '../../../../../types/mentionable'
+import { fileToMentionableImage } from '../../../../../utils/image'
+
+export default function DragDropPaste({
+  onCreateImageMentionables,
+}: {
+  onCreateImageMentionables?: (mentionables: MentionableImage[]) => void
+}): null {
+  const [editor] = useLexicalComposerContext()
+
+  useEffect(() => {
+    return editor.registerCommand(
+      DRAG_DROP_PASTE, // dispatched in RichTextPlugin
+      (files) => {
+        ;(async () => {
+          const images = files.filter((file) => file.type.startsWith('image/'))
+          const mentionableImages = await Promise.all(
+            images.map(async (image) => await fileToMentionableImage(image)),
+          )
+          onCreateImageMentionables?.(mentionableImages)
+        })()
+        return true
+      },
+      COMMAND_PRIORITY_LOW,
+    )
+  }, [editor, onCreateImageMentionables])
+
+  return null
+}

--- a/src/components/chat-view/chat-input/plugins/image/ImagePastePlugin.tsx
+++ b/src/components/chat-view/chat-input/plugins/image/ImagePastePlugin.tsx
@@ -1,0 +1,51 @@
+import { useLexicalComposerContext } from '@lexical/react/LexicalComposerContext'
+import { COMMAND_PRIORITY_LOW, PASTE_COMMAND, PasteCommandType } from 'lexical'
+import { useEffect } from 'react'
+
+import { MentionableImage } from '../../../../../types/mentionable'
+
+export default function ImagePastePlugin({
+  onCreateImageMentionable,
+}: {
+  onCreateImageMentionable?: (mentionable: MentionableImage) => void
+}) {
+  const [editor] = useLexicalComposerContext()
+
+  useEffect(() => {
+    const handlePaste = (event: PasteCommandType) => {
+      const clipboardData =
+        event instanceof ClipboardEvent ? event.clipboardData : null
+      if (!clipboardData) return false
+
+      const images = Array.from(clipboardData.files).filter((file) =>
+        file.type.startsWith('image/'),
+      )
+      if (images.length === 0) return false
+
+      images.forEach((image) => {
+        const reader = new FileReader()
+        reader.onload = () => {
+          const base64Data = reader.result as string
+          const mentionable: MentionableImage = {
+            type: 'image',
+            name: image.name,
+            mimeType: image.type,
+            data: base64Data,
+          }
+          onCreateImageMentionable?.(mentionable)
+        }
+        reader.readAsDataURL(image)
+      })
+
+      return true
+    }
+
+    return editor.registerCommand(
+      PASTE_COMMAND,
+      handlePaste,
+      COMMAND_PRIORITY_LOW,
+    )
+  }, [editor, onCreateImageMentionable])
+
+  return null
+}

--- a/src/components/chat-view/chat-input/utils/get-metionable-icon.ts
+++ b/src/components/chat-view/chat-input/utils/get-metionable-icon.ts
@@ -1,4 +1,10 @@
-import { FileIcon, FolderClosedIcon, FoldersIcon, LinkIcon } from 'lucide-react'
+import {
+  FileIcon,
+  FolderClosedIcon,
+  FoldersIcon,
+  ImageIcon,
+  LinkIcon,
+} from 'lucide-react'
 
 import { Mentionable } from '../../../../types/mentionable'
 
@@ -16,6 +22,8 @@ export const getMentionableIcon = (mentionable: Mentionable) => {
       return FileIcon
     case 'url':
       return LinkIcon
+    case 'image':
+      return ImageIcon
     default:
       return null
   }

--- a/src/core/llm/anthropic.ts
+++ b/src/core/llm/anthropic.ts
@@ -1,7 +1,9 @@
 import Anthropic from '@anthropic-ai/sdk'
 import {
+  ImageBlockParam,
   MessageParam,
   MessageStreamEvent,
+  TextBlockParam,
 } from '@anthropic-ai/sdk/resources/messages'
 
 import { LLMModel } from '../../types/llm/model'
@@ -16,6 +18,7 @@ import {
   LLMResponseStreaming,
   ResponseUsage,
 } from '../../types/llm/response'
+import { parseImageDataUrl } from '../../utils/image'
 
 import { BaseLLMProvider } from './base'
 import {
@@ -41,10 +44,7 @@ export class AnthropicProvider implements BaseLLMProvider {
       )
     }
 
-    const systemMessages = request.messages.filter((m) => m.role === 'system')
-    if (systemMessages.length > 1) {
-      throw new Error('Anthropic does not support more than one system message')
-    }
+    const systemMessage = this.validateSystemMessages(request.messages)
 
     try {
       const response = await this.client.messages.create(
@@ -53,8 +53,7 @@ export class AnthropicProvider implements BaseLLMProvider {
           messages: request.messages
             .filter((m) => m.role !== 'system')
             .map((m) => AnthropicProvider.parseRequestMessage(m)),
-          system:
-            systemMessages.length > 0 ? systemMessages[0].content : undefined,
+          system: systemMessage,
           max_tokens: request.max_tokens ?? 4096,
           temperature: request.temperature,
           top_p: request.top_p,
@@ -87,10 +86,7 @@ export class AnthropicProvider implements BaseLLMProvider {
       )
     }
 
-    const systemMessages = request.messages.filter((m) => m.role === 'system')
-    if (systemMessages.length > 1) {
-      throw new Error('Anthropic does not support more than one system message')
-    }
+    const systemMessage = this.validateSystemMessages(request.messages)
 
     try {
       const stream = await this.client.messages.create(
@@ -99,8 +95,7 @@ export class AnthropicProvider implements BaseLLMProvider {
           messages: request.messages
             .filter((m) => m.role !== 'system')
             .map((m) => AnthropicProvider.parseRequestMessage(m)),
-          system:
-            systemMessages.length > 0 ? systemMessages[0].content : undefined,
+          system: systemMessage,
           max_tokens: request.max_tokens ?? 4096,
           temperature: request.temperature,
           top_p: request.top_p,
@@ -172,11 +167,39 @@ export class AnthropicProvider implements BaseLLMProvider {
 
   static parseRequestMessage(message: RequestMessage): MessageParam {
     if (message.role !== 'user' && message.role !== 'assistant') {
-      throw new Error('Unsupported role')
+      throw new Error(`Anthropic does not support role: ${message.role}`)
     }
+
+    if (message.role === 'user' && Array.isArray(message.content)) {
+      const content = message.content.map(
+        (part): TextBlockParam | ImageBlockParam => {
+          switch (part.type) {
+            case 'text':
+              return { type: 'text', text: part.text }
+            case 'image_url': {
+              const { mimeType, base64Data } = parseImageDataUrl(
+                part.image_url.url,
+              )
+              AnthropicProvider.validateImageType(mimeType)
+              return {
+                type: 'image',
+                source: {
+                  data: base64Data,
+                  media_type:
+                    mimeType as ImageBlockParam['source']['media_type'],
+                  type: 'base64',
+                },
+              }
+            }
+          }
+        },
+      )
+      return { role: 'user', content }
+    }
+
     return {
       role: message.role,
-      content: message.content,
+      content: message.content as string,
     }
   }
 
@@ -231,6 +254,39 @@ export class AnthropicProvider implements BaseLLMProvider {
       ],
       object: 'chat.completion.chunk',
       model: model,
+    }
+  }
+
+  private validateSystemMessages(
+    messages: RequestMessage[],
+  ): string | undefined {
+    const systemMessages = messages.filter((m) => m.role === 'system')
+    if (systemMessages.length > 1) {
+      throw new Error(`Anthropic does not support more than one system message`)
+    }
+    const systemMessage =
+      systemMessages.length > 0 ? systemMessages[0].content : undefined
+    if (systemMessage && typeof systemMessage !== 'string') {
+      throw new Error(
+        `Anthropic only supports string content for system messages`,
+      )
+    }
+    return systemMessage
+  }
+
+  private static validateImageType(mimeType: string) {
+    const SUPPORTED_IMAGE_TYPES = [
+      'image/jpeg',
+      'image/png',
+      'image/gif',
+      'image/webp',
+    ]
+    if (!SUPPORTED_IMAGE_TYPES.includes(mimeType)) {
+      throw new Error(
+        `Anthropic does not support image type ${mimeType}. Supported types: ${SUPPORTED_IMAGE_TYPES.join(
+          ', ',
+        )}`,
+      )
     }
   }
 }

--- a/src/core/llm/groq.ts
+++ b/src/core/llm/groq.ts
@@ -2,6 +2,7 @@ import Groq from 'groq-sdk'
 import {
   ChatCompletion,
   ChatCompletionChunk,
+  ChatCompletionContentPart,
   ChatCompletionMessageParam,
 } from 'groq-sdk/resources/chat/completions'
 
@@ -119,9 +120,32 @@ export class GroqProvider implements BaseLLMProvider {
   static parseRequestMessage(
     message: RequestMessage,
   ): ChatCompletionMessageParam {
-    return {
-      role: message.role,
-      content: message.content,
+    switch (message.role) {
+      case 'user': {
+        const content = Array.isArray(message.content)
+          ? message.content.map((part): ChatCompletionContentPart => {
+              switch (part.type) {
+                case 'text':
+                  return { type: 'text', text: part.text }
+                case 'image_url':
+                  return { type: 'image_url', image_url: part.image_url }
+              }
+            })
+          : message.content
+        return { role: 'user', content }
+      }
+      case 'assistant': {
+        if (Array.isArray(message.content)) {
+          throw new Error('Assistant message should be a string')
+        }
+        return { role: 'assistant', content: message.content }
+      }
+      case 'system': {
+        if (Array.isArray(message.content)) {
+          throw new Error('System message should be a string')
+        }
+        return { role: 'system', content: message.content }
+      }
     }
   }
 

--- a/src/types/chat.ts
+++ b/src/types/chat.ts
@@ -3,13 +3,14 @@ import { SerializedEditorState } from 'lexical'
 import { SelectVector } from '../database/schema'
 
 import { LLMModel } from './llm/model'
+import { ContentPart } from './llm/request'
 import { ResponseUsage } from './llm/response'
 import { Mentionable, SerializedMentionable } from './mentionable'
 
 export type ChatUserMessage = {
   role: 'user'
   content: SerializedEditorState | null
-  promptContent: string | null
+  promptContent: string | ContentPart[] | null
   id: string
   mentionables: Mentionable[]
   similaritySearchResults?: (Omit<SelectVector, 'embedding'> & {
@@ -30,7 +31,7 @@ export type ChatMessage = ChatUserMessage | ChatAssistantMessage
 export type SerializedChatUserMessage = {
   role: 'user'
   content: SerializedEditorState | null
-  promptContent: string | null
+  promptContent: string | ContentPart[] | null
   id: string
   mentionables: SerializedMentionable[]
   similaritySearchResults?: (Omit<SelectVector, 'embedding'> & {

--- a/src/types/llm/request.ts
+++ b/src/types/llm/request.ts
@@ -31,9 +31,24 @@ export type LLMRequestStreaming = LLMRequestBase & {
 
 export type LLMRequest = LLMRequestNonStreaming | LLMRequestStreaming
 
+type TextContent = {
+  type: 'text'
+  text: string
+}
+
+type ImageContentPart = {
+  type: 'image_url'
+  image_url: {
+    url: string // URL or base64 encoded image data
+  }
+}
+
+export type ContentPart = TextContent | ImageContentPart
+
 export type RequestMessage = {
   role: 'user' | 'assistant' | 'system'
-  content: string
+  // ContentParts are only for the 'user' role:
+  content: string | ContentPart[]
 }
 
 export type LLMOptions = {

--- a/src/types/mentionable.ts
+++ b/src/types/mentionable.ts
@@ -28,6 +28,12 @@ export type MentionableUrl = {
   type: 'url'
   url: string
 }
+export type MentionableImage = {
+  type: 'image'
+  name: string
+  mimeType: string
+  data: string // base64
+}
 export type Mentionable =
   | MentionableFile
   | MentionableFolder
@@ -35,7 +41,7 @@ export type Mentionable =
   | MentionableCurrentFile
   | MentionableBlock
   | MentionableUrl
-
+  | MentionableImage
 export type SerializedMentionableFile = {
   type: 'file'
   file: string
@@ -44,9 +50,7 @@ export type SerializedMentionableFolder = {
   type: 'folder'
   folder: string
 }
-export type SerializedMentionableVault = {
-  type: 'vault'
-}
+export type SerializedMentionableVault = MentionableVault
 export type SerializedMentionableCurrentFile = {
   type: 'current-file'
   file: string | null
@@ -58,10 +62,8 @@ export type SerializedMentionableBlock = {
   startLine: number
   endLine: number
 }
-export type SerializedMentionableUrl = {
-  type: 'url'
-  url: string
-}
+export type SerializedMentionableUrl = MentionableUrl
+export type SerializedMentionableImage = MentionableImage
 export type SerializedMentionable =
   | SerializedMentionableFile
   | SerializedMentionableFolder
@@ -69,3 +71,4 @@ export type SerializedMentionable =
   | SerializedMentionableCurrentFile
   | SerializedMentionableBlock
   | SerializedMentionableUrl
+  | SerializedMentionableImage

--- a/src/utils/image.ts
+++ b/src/utils/image.ts
@@ -1,0 +1,11 @@
+export function parseImageDataUrl(dataUrl: string): {
+  mimeType: string
+  base64Data: string
+} {
+  const matches = dataUrl.match(/^data:([^;]+);base64,(.+)/)
+  if (!matches) {
+    throw new Error('Invalid image data URL format')
+  }
+  const [, mimeType, base64Data] = matches
+  return { mimeType, base64Data }
+}

--- a/src/utils/image.ts
+++ b/src/utils/image.ts
@@ -1,3 +1,5 @@
+import { MentionableImage } from '../types/mentionable'
+
 export function parseImageDataUrl(dataUrl: string): {
   mimeType: string
   base64Data: string
@@ -8,4 +10,25 @@ export function parseImageDataUrl(dataUrl: string): {
   }
   const [, mimeType, base64Data] = matches
   return { mimeType, base64Data }
+}
+
+export async function fileToMentionableImage(
+  file: File,
+): Promise<MentionableImage> {
+  const base64Data = await fileToBase64(file)
+  return {
+    type: 'image',
+    name: file.name,
+    mimeType: file.type,
+    data: base64Data,
+  }
+}
+
+function fileToBase64(file: File): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const reader = new FileReader()
+    reader.readAsDataURL(file)
+    reader.onload = () => resolve(reader.result as string)
+    reader.onerror = () => reject(new Error('Failed to read file'))
+  })
 }

--- a/src/utils/mentionable.ts
+++ b/src/utils/mentionable.ts
@@ -38,6 +38,13 @@ export const serializeMentionable = (
         type: 'url',
         url: mentionable.url,
       }
+    case 'image':
+      return {
+        type: 'image',
+        name: mentionable.name,
+        mimeType: mentionable.mimeType,
+        data: mentionable.data,
+      }
   }
 }
 
@@ -103,6 +110,14 @@ export const deserializeMentionable = (
           url: mentionable.url,
         }
       }
+      case 'image': {
+        return {
+          type: 'image',
+          name: mentionable.name,
+          mimeType: mentionable.mimeType,
+          data: mentionable.data,
+        }
+      }
     }
   } catch (e) {
     console.error('Error deserializing mentionable', e)
@@ -124,6 +139,8 @@ export function getMentionableKey(mentionable: SerializedMentionable): string {
       return `block:${mentionable.file}:${mentionable.startLine}:${mentionable.endLine}:${mentionable.content}`
     case 'url':
       return `url:${mentionable.url}`
+    case 'image':
+      return `image:${mentionable.name}:${mentionable.data.length}:${mentionable.data.slice(-32)}`
   }
 }
 
@@ -141,5 +158,7 @@ export function getMentionableName(mentionable: Mentionable): string {
       return `${mentionable.file.name} (${mentionable.startLine}:${mentionable.endLine})`
     case 'url':
       return mentionable.url
+    case 'image':
+      return mentionable.name
   }
 }

--- a/styles.css
+++ b/styles.css
@@ -241,7 +241,13 @@ button:not(.clickable-icon).smtcmp-chat-list-dropdown {
   align-items: center;
   height: var(--size-4-4);
 
-  .smtcmp-chat-user-input-controls-buttons {
+  .smtcmp-chat-user-input-controls__model-select-container {
+    flex-shrink: 1;
+    overflow: hidden;
+  }
+
+  .smtcmp-chat-user-input-controls__buttons {
+    flex-shrink: 0;
     display: flex;
     gap: var(--size-4-2);
     align-items: center;
@@ -718,11 +724,27 @@ button.smtcmp-chat-input-model-select {
   font-weight: var(--font-medium);
   color: var(--text-muted);
   justify-content: flex-start;
+  align-items: center;
+  cursor: pointer;
   height: var(--size-4-4);
-  width: fit-content;
+  max-width: 100%;
 
   &:hover {
     color: var(--text-normal);
+  }
+
+  .smtcmp-chat-input-model-select__model-name {
+    flex-shrink: 1;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+
+  .smtcmp-chat-input-model-select__icon {
+    flex-shrink: 0;
+    display: flex;
+    align-items: center;
+    justify-content: center;
   }
 }
 

--- a/styles.css
+++ b/styles.css
@@ -285,6 +285,10 @@ button:not(.clickable-icon).smtcmp-chat-list-dropdown {
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
+
+  &.smtcmp-chat-user-input-file-badge-focused {
+    border: 1px solid var(--interactive-accent);
+  }
 }
 
 .smtcmp-chat-user-input-file-badge:hover {
@@ -333,6 +337,11 @@ button:not(.clickable-icon).smtcmp-chat-list-dropdown {
   max-height: 350px;
   overflow-y: auto;
   white-space: pre-line;
+
+  img {
+    max-width: 100%;
+    max-height: 350px;
+  }
 }
 
 /**


### PR DESCRIPTION
# Image Support for Chat Messages

This PR adds support for image uploads and display in chat messages, enabling users to include images in their conversations.

## Key Changes

- Added image upload button in chat input
- Image paste support via `ImagePastePlugin`
- Preview of uploaded images in the chat interface
- Add support for handling image content in messages across LLM providers