### PR TITLE
enhance fuzzy search using name and path keys

### DIFF
--- a/src/utils/obsidian.test.ts
+++ b/src/utils/obsidian.test.ts
@@ -1,4 +1,4 @@
-import { TFile } from 'obsidian'
+import { TFile, TFolder } from 'obsidian'
 
 import { calculateFileDistance } from './obsidian'
 
@@ -48,5 +48,13 @@ describe('calculateFileDistance', () => {
 
     const result = calculateFileDistance(file, file)
     expect(result).toBe(0)
+  })
+
+  it('should calculate the correct distance between a folder and a file', () => {
+    const file = new MockTFile('folder1/folder2/file1.md') as TFile
+    const folder = new MockTFile('folder1/folder2') as TFolder
+
+    const result = calculateFileDistance(file, folder)
+    expect(result).toBe(1)
   })
 })

--- a/src/utils/obsidian.ts
+++ b/src/utils/obsidian.ts
@@ -67,8 +67,8 @@ export function getOpenFiles(app: App): TFile[] {
 }
 
 export function calculateFileDistance(
-  file1: TFile,
-  file2: TFile,
+  file1: TFile | TFolder,
+  file2: TFile | TFolder,
 ): number | null {
   const path1 = file1.path.split('/')
   const path2 = file2.path.split('/')


### PR DESCRIPTION
this fixes https://github.com/glowingjade/obsidian-smart-composer/issues/130

- Improve search accuracy by considering both file names and paths in fuzzy matching
- Implement folder scoring with distance-based boost