### PR TITLE
fix: make ollama model selection work

### DIFF
--- a/src/settings/SettingTab.tsx
+++ b/src/settings/SettingTab.tsx
@@ -254,7 +254,10 @@ export class SmartCopilotSettingTab extends PluginSettingTab {
       .setName('Model Name')
       .setDesc('Select a model from your Ollama instance')
       .addDropdown(async (dropdown) => {
+        const currentModel = this.plugin.settings.ollamaChatModel.model
         modelDropdown = dropdown
+          .addOption(currentModel, currentModel)
+          .setValue(currentModel)
         await this.updateOllamaModelOptions({
           baseUrl: this.plugin.settings.ollamaChatModel.baseUrl,
           dropdown,
@@ -384,7 +387,10 @@ export class SmartCopilotSettingTab extends PluginSettingTab {
       .setName('Model Name')
       .setDesc('Select a model from your Ollama instance')
       .addDropdown(async (dropdown) => {
+        const currentModel = this.plugin.settings.ollamaApplyModel.model
         modelDropdown = dropdown
+          .addOption(currentModel, currentModel)
+          .setValue(currentModel)
         await this.updateOllamaModelOptions({
           baseUrl: this.plugin.settings.ollamaApplyModel.baseUrl,
           dropdown,
@@ -703,6 +709,10 @@ export class SmartCopilotSettingTab extends PluginSettingTab {
       dropdown.setValue('')
       await onModelChange('')
     }
+
+    dropdown.onChange(async (value) => {
+      await onModelChange(value)
+    })
   }
 }
 


### PR DESCRIPTION
Thank you for developing such an excellent plugin!

I found ollama model name selection does not work.
![241213obsidian-smart-composer-modelname-set-failure](https://github.com/user-attachments/assets/d87b1e44-625c-4443-8099-292403298a19)

The current implementation appears to have two issues:
- [x] Selected models are not saved into `data.json`.
  - fixed in l712-715
- [x]  Selected model names are reset to the default ones when opening or refreshing the settings tab.
  - This happens because `dropdown.getValue()` returns nothing if there is no corresponding option.

I should mention that I’m not very familiar with this project or, more generally, with Obsidian plugin development. If there are any conventions or best practices that I’ve overlooked, please know it’s unintentional, and I’d appreciate it if you could point them out.