### PR TITLE
Add Deepseek R1 support

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,14 @@ Note: The Apply Edit feature is currently slower than desired. We are working on
 - **Prompt Templates**: Create and reuse templates for common queries by typing `/` in the chat view. Perfect for standardizing repetitive tasks.
   - Create templates from any selected text with one click
 
+### Deepseek R1 Support
+
+> **Deepseek R1** is now supported with a separate `deepseekProvider` and accompanying UI elements in settings.
+
+- Added `deepseekProvider` implementation in `src/core/llm/manager.ts` and `src/core/llm/deepseek.ts`.
+- Updated `CHAT_MODEL_OPTIONS` and `APPLY_MODEL_OPTIONS` in `src/constants.ts` to include Deepseek R1.
+- Added Deepseek R1 specific settings UI in `src/settings/SettingTab.tsx`.
+
 ## Getting Started
 
 > **⚠️ Important: Installer Version Requirement**  

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -88,6 +88,16 @@ export const CHAT_MODEL_OPTIONS: ModelOption[] = [
       baseURL: '',
     },
   },
+  {
+    id: 'deepseek',
+    name: 'Deepseek R1',
+    model: {
+      provider: 'deepseek',
+      model: 'deepseek-r1',
+      apiKey: '',
+      baseURL: 'https://api.deepseek.com/v1',
+    },
+  },
 ]
 
 export const APPLY_MODEL_OPTIONS: ModelOption[] = [
@@ -156,6 +166,16 @@ export const APPLY_MODEL_OPTIONS: ModelOption[] = [
       model: '',
       apiKey: '',
       baseURL: '',
+    },
+  },
+  {
+    id: 'deepseek',
+    name: 'Deepseek R1',
+    model: {
+      provider: 'deepseek',
+      model: 'deepseek-r1',
+      apiKey: '',
+      baseURL: 'https://api.deepseek.com/v1',
     },
   },
 ]

--- a/src/core/llm/deepseek.ts
+++ b/src/core/llm/deepseek.ts
@@ -1,0 +1,131 @@
+import { LLMModel } from '../../types/llm/model'
+import {
+  LLMOptions,
+  LLMRequestNonStreaming,
+  LLMRequestStreaming,
+} from '../../types/llm/request'
+import {
+  LLMResponseNonStreaming,
+  LLMResponseStreaming,
+} from '../../types/llm/response'
+
+import { BaseLLMProvider } from './base'
+import {
+  LLMAPIKeyInvalidException,
+  LLMAPIKeyNotSetException,
+} from './exception'
+
+export class DeepseekProvider implements BaseLLMProvider {
+  private apiKey: string
+  private baseUrl: string
+
+  constructor(apiKey: string, baseUrl: string) {
+    this.apiKey = apiKey
+    this.baseUrl = baseUrl
+  }
+
+  async generateResponse(
+    model: LLMModel,
+    request: LLMRequestNonStreaming,
+    options?: LLMOptions,
+  ): Promise<LLMResponseNonStreaming> {
+    if (!this.apiKey) {
+      throw new LLMAPIKeyNotSetException(
+        'Deepseek API key is missing. Please set it in settings menu.',
+      )
+    }
+
+    const response = await fetch(`${this.baseUrl}/v1/completions`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${this.apiKey}`,
+      },
+      body: JSON.stringify({
+        model: request.model,
+        messages: request.messages,
+        max_tokens: request.max_tokens,
+        temperature: request.temperature,
+        top_p: request.top_p,
+      }),
+      signal: options?.signal,
+    })
+
+    if (!response.ok) {
+      if (response.status === 401) {
+        throw new LLMAPIKeyInvalidException(
+          'Deepseek API key is invalid. Please update it in settings menu.',
+        )
+      }
+      throw new Error(`Deepseek API request failed with status ${response.status}`)
+    }
+
+    const data = await response.json()
+    return {
+      id: data.id,
+      choices: data.choices,
+      model: data.model,
+      object: 'chat.completion',
+      usage: data.usage,
+    }
+  }
+
+  async streamResponse(
+    model: LLMModel,
+    request: LLMRequestStreaming,
+    options?: LLMOptions,
+  ): Promise<AsyncIterable<LLMResponseStreaming>> {
+    if (!this.apiKey) {
+      throw new LLMAPIKeyNotSetException(
+        'Deepseek API key is missing. Please set it in settings menu.',
+      )
+    }
+
+    const response = await fetch(`${this.baseUrl}/v1/completions`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${this.apiKey}`,
+      },
+      body: JSON.stringify({
+        model: request.model,
+        messages: request.messages,
+        max_tokens: request.max_tokens,
+        temperature: request.temperature,
+        top_p: request.top_p,
+        stream: true,
+      }),
+      signal: options?.signal,
+    })
+
+    if (!response.ok) {
+      if (response.status === 401) {
+        throw new LLMAPIKeyInvalidException(
+          'Deepseek API key is invalid. Please update it in settings menu.',
+        )
+      }
+      throw new Error(`Deepseek API request failed with status ${response.status}`)
+    }
+
+    const reader = response.body?.getReader()
+    if (!reader) {
+      throw new Error('Failed to get reader from response body')
+    }
+
+    async function* streamResponseGenerator() {
+      const decoder = new TextDecoder()
+      let done = false
+
+      while (!done) {
+        const { value, done: readerDone } = await reader.read()
+        done = readerDone
+        if (value) {
+          const chunk = decoder.decode(value, { stream: true })
+          yield JSON.parse(chunk)
+        }
+      }
+    }
+
+    return streamResponseGenerator()
+  }
+}

--- a/src/core/llm/manager.ts
+++ b/src/core/llm/manager.ts
@@ -15,6 +15,7 @@ import { GroqProvider } from './groq'
 import { OllamaProvider } from './ollama'
 import { OpenAIAuthenticatedProvider } from './openai'
 import { OpenAICompatibleProvider } from './openaiCompatibleProvider'
+import { DeepseekProvider } from './deepseek'
 
 export type LLMManagerInterface = {
   generateResponse(
@@ -36,12 +37,14 @@ class LLMManager implements LLMManagerInterface {
   private groqProvider: GroqProvider
   private ollamaProvider: OllamaProvider
   private openaiCompatibleProvider: OpenAICompatibleProvider
+  private deepseekProvider: DeepseekProvider
 
   constructor(apiKeys: {
     openai?: string
     anthropic?: string
     gemini?: string
     groq?: string
+    deepseek?: string
   }) {
     this.openaiProvider = new OpenAIAuthenticatedProvider(apiKeys.openai ?? '')
     this.anthropicProvider = new AnthropicProvider(apiKeys.anthropic ?? '')
@@ -49,6 +52,7 @@ class LLMManager implements LLMManagerInterface {
     this.groqProvider = new GroqProvider(apiKeys.groq ?? '')
     this.ollamaProvider = new OllamaProvider()
     this.openaiCompatibleProvider = new OpenAICompatibleProvider()
+    this.deepseekProvider = new DeepseekProvider(apiKeys.deepseek ?? '', 'https://api.deepseek.com/v1')
   }
 
   async generateResponse(
@@ -89,6 +93,12 @@ class LLMManager implements LLMManagerInterface {
           request,
           options,
         )
+      case 'deepseek':
+        return await this.deepseekProvider.generateResponse(
+          model,
+          request,
+          options,
+        )
     }
   }
 
@@ -119,6 +129,12 @@ class LLMManager implements LLMManagerInterface {
         return await this.ollamaProvider.streamResponse(model, request, options)
       case 'openai-compatible':
         return await this.openaiCompatibleProvider.streamResponse(
+          model,
+          request,
+          options,
+        )
+      case 'deepseek':
+        return await this.deepseekProvider.streamResponse(
           model,
           request,
           options,

--- a/src/settings/SettingTab.tsx
+++ b/src/settings/SettingTab.tsx
@@ -128,6 +128,9 @@ export class SmartCopilotSettingTab extends PluginSettingTab {
     if (this.plugin.settings.chatModelId === 'openai-compatible') {
       this.renderOpenAICompatibleChatModelSettings(containerEl)
     }
+    if (this.plugin.settings.chatModelId === 'deepseek') {
+      this.renderDeepseekChatModelSettings(containerEl)
+    }
 
     new Setting(containerEl)
       .setName('Apply model')
@@ -158,6 +161,9 @@ export class SmartCopilotSettingTab extends PluginSettingTab {
     }
     if (this.plugin.settings.applyModelId === 'openai-compatible') {
       this.renderOpenAICompatibleApplyModelSettings(containerEl)
+    }
+    if (this.plugin.settings.applyModelId === 'deepseek') {
+      this.renderDeepseekApplyModelSettings(containerEl)
     }
 
     new Setting(containerEl)
@@ -340,6 +346,70 @@ export class SmartCopilotSettingTab extends PluginSettingTab {
       )
   }
 
+  renderDeepseekChatModelSettings(containerEl: HTMLElement): void {
+    const deepseekContainer = containerEl.createDiv(
+      'smtcmp-settings-model-container',
+    )
+
+    new Setting(deepseekContainer)
+      .setName('Base URL')
+      .setDesc(
+        'The API endpoint for your Deepseek service (e.g., https://api.deepseek.com/v1)',
+      )
+      .addText((text) =>
+        text
+          .setPlaceholder('https://api.deepseek.com/v1')
+          .setValue(this.plugin.settings.deepseekChatModel.baseUrl || '')
+          .onChange(async (value) => {
+            await this.plugin.setSettings({
+              ...this.plugin.settings,
+              deepseekChatModel: {
+                ...this.plugin.settings.deepseekChatModel,
+                baseUrl: value,
+              },
+            })
+          }),
+      )
+
+    new Setting(deepseekContainer)
+      .setName('API Key')
+      .setDesc('Your authentication key for the Deepseek service')
+      .addText((text) =>
+        text
+          .setPlaceholder('Enter your API key')
+          .setValue(this.plugin.settings.deepseekChatModel.apiKey || '')
+          .onChange(async (value) => {
+            await this.plugin.setSettings({
+              ...this.plugin.settings,
+              deepseekChatModel: {
+                ...this.plugin.settings.deepseekChatModel,
+                apiKey: value,
+              },
+            })
+          }),
+      )
+
+    new Setting(deepseekContainer)
+      .setName('Model Name')
+      .setDesc(
+        'The specific model to use with your service (e.g., deepseek-r1)',
+      )
+      .addText((text) =>
+        text
+          .setPlaceholder('deepseek-r1')
+          .setValue(this.plugin.settings.deepseekChatModel.model || '')
+          .onChange(async (value) => {
+            await this.plugin.setSettings({
+              ...this.plugin.settings,
+              deepseekChatModel: {
+                ...this.plugin.settings.deepseekChatModel,
+                model: value,
+              },
+            })
+          }),
+      )
+  }
+
   renderOllamaApplyModelSettings(containerEl: HTMLElement): void {
     const ollamaContainer = containerEl.createDiv(
       'smtcmp-settings-model-container',
@@ -468,6 +538,70 @@ export class SmartCopilotSettingTab extends PluginSettingTab {
               ...this.plugin.settings,
               openAICompatibleApplyModel: {
                 ...this.plugin.settings.openAICompatibleApplyModel,
+                model: value,
+              },
+            })
+          }),
+      )
+  }
+
+  renderDeepseekApplyModelSettings(containerEl: HTMLElement): void {
+    const deepseekContainer = containerEl.createDiv(
+      'smtcmp-settings-model-container',
+    )
+
+    new Setting(deepseekContainer)
+      .setName('Base URL')
+      .setDesc(
+        'The API endpoint for your Deepseek service (e.g., https://api.deepseek.com/v1)',
+      )
+      .addText((text) =>
+        text
+          .setPlaceholder('https://api.deepseek.com/v1')
+          .setValue(this.plugin.settings.deepseekApplyModel.baseUrl || '')
+          .onChange(async (value) => {
+            await this.plugin.setSettings({
+              ...this.plugin.settings,
+              deepseekApplyModel: {
+                ...this.plugin.settings.deepseekApplyModel,
+                baseUrl: value,
+              },
+            })
+          }),
+      )
+
+    new Setting(deepseekContainer)
+      .setName('API Key')
+      .setDesc('Your authentication key for the Deepseek service')
+      .addText((text) =>
+        text
+          .setPlaceholder('Enter your API key')
+          .setValue(this.plugin.settings.deepseekApplyModel.apiKey || '')
+          .onChange(async (value) => {
+            await this.plugin.setSettings({
+              ...this.plugin.settings,
+              deepseekApplyModel: {
+                ...this.plugin.settings.deepseekApplyModel,
+                apiKey: value,
+              },
+            })
+          }),
+      )
+
+    new Setting(deepseekContainer)
+      .setName('Model Name')
+      .setDesc(
+        'The specific model to use with your service (e.g., deepseek-r1)',
+      )
+      .addText((text) =>
+        text
+          .setPlaceholder('deepseek-r1')
+          .setValue(this.plugin.settings.deepseekApplyModel.model || '')
+          .onChange(async (value) => {
+            await this.plugin.setSettings({
+              ...this.plugin.settings,
+              deepseekApplyModel: {
+                ...this.plugin.settings.deepseekApplyModel,
                 model: value,
               },
             })


### PR DESCRIPTION
Related to #217

Add support for Deepseek R1 with a separate `deepseekProvider` and accompanying UI elements in settings.

* **DeepseekProvider Implementation**:
  - Add `DeepseekProvider` class in `src/core/llm/deepseek.ts` for handling Deepseek R1 API requests.
  - Include methods for `generateResponse` and `streamResponse`.

* **LLM Manager**:
  - Import `DeepseekProvider` class in `src/core/llm/manager.ts`.
  - Add `deepseekProvider` instance in the constructor.
  - Update `generateResponse` and `streamResponse` methods to handle `deepseek` provider.

* **Constants**:
  - Add Deepseek R1 to `CHAT_MODEL_OPTIONS` and `APPLY_MODEL_OPTIONS` in `src/constants.ts`.

* **Settings UI**:
  - Add settings UI for Deepseek R1 under `renderModelSection` in `src/settings/SettingTab.tsx`.

* **Documentation**:
  - Update `README.md` to include Deepseek R1 support.

