### PR TITLE
add no stainless headers toggle setting for openai compatible provider

### DIFF
--- a/src/components/common/ObsidianToggle.tsx
+++ b/src/components/common/ObsidianToggle.tsx
@@ -1,0 +1,46 @@
+import { ToggleComponent } from 'obsidian'
+import { useEffect, useRef, useState } from 'react'
+
+import { useObsidianSetting } from './ObsidianSetting'
+
+type ObsidianToggleProps = {
+  value: boolean
+  onChange: (value: boolean) => void
+}
+
+export function ObsidianToggle({ value, onChange }: ObsidianToggleProps) {
+  const containerRef = useRef<HTMLDivElement>(null)
+  const { setting } = useObsidianSetting()
+  const [toggleComponent, setToggleComponent] =
+    useState<ToggleComponent | null>(null)
+
+  useEffect(() => {
+    if (setting) {
+      let newToggleComponent: ToggleComponent | null = null
+      setting.addToggle((component) => {
+        newToggleComponent = component
+      })
+      setToggleComponent(newToggleComponent)
+
+      return () => {
+        newToggleComponent?.toggleEl.remove()
+      }
+    } else if (containerRef.current) {
+      const newToggleComponent = new ToggleComponent(containerRef.current)
+      setToggleComponent(newToggleComponent)
+
+      return () => {
+        newToggleComponent?.toggleEl.remove()
+      }
+    }
+  }, [setting])
+
+  useEffect(() => {
+    if (!toggleComponent) return
+
+    toggleComponent.setValue(value)
+    toggleComponent.onChange(onChange)
+  }, [toggleComponent, value, onChange])
+
+  return <div ref={containerRef} />
+}

--- a/src/components/settings/ProviderFormModalRoot.tsx
+++ b/src/components/settings/ProviderFormModalRoot.tsx
@@ -8,6 +8,7 @@ import { ObsidianButton } from '../common/ObsidianButton'
 import { ObsidianDropdown } from '../common/ObsidianDropdown'
 import { ObsidianSetting } from '../common/ObsidianSetting'
 import { ObsidianTextInput } from '../common/ObsidianTextInput'
+import { ObsidianToggle } from '../common/ObsidianToggle'
 
 export default function ProviderFormModalRoot({
   plugin,
@@ -158,24 +159,51 @@ export default function ProviderFormModalRoot({
         <ObsidianSetting
           key={setting.key}
           name={setting.label}
+          desc={'description' in setting ? setting.description : undefined}
           required={setting.required}
         >
-          <ObsidianTextInput
-            value={formData.additionalSettings?.[setting.key] ?? ''}
-            placeholder={setting.placeholder}
-            onChange={(value: string) =>
-              setFormData(
-                (prev) =>
-                  ({
-                    ...prev,
-                    additionalSettings: {
-                      ...(prev.additionalSettings ?? {}),
-                      [setting.key]: value,
-                    },
-                  }) as LLMProvider,
-              )
-            }
-          />
+          {setting.type === 'toggle' ? (
+            <ObsidianToggle
+              value={
+                (formData.additionalSettings as Record<string, boolean>)?.[
+                  setting.key
+                ] ?? false
+              }
+              onChange={(value: boolean) =>
+                setFormData(
+                  (prev) =>
+                    ({
+                      ...prev,
+                      additionalSettings: {
+                        ...(prev.additionalSettings ?? {}),
+                        [setting.key]: value,
+                      },
+                    }) as LLMProvider,
+                )
+              }
+            />
+          ) : (
+            <ObsidianTextInput
+              value={
+                (formData.additionalSettings as Record<string, string>)?.[
+                  setting.key
+                ] ?? ''
+              }
+              placeholder={setting.placeholder}
+              onChange={(value: string) =>
+                setFormData(
+                  (prev) =>
+                    ({
+                      ...prev,
+                      additionalSettings: {
+                        ...(prev.additionalSettings ?? {}),
+                        [setting.key]: value,
+                      },
+                    }) as LLMProvider,
+                )
+              }
+            />
+          )}
         </ObsidianSetting>
       ))}
 

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -128,7 +128,16 @@ export const PROVIDER_TYPES_INFO = {
     requireApiKey: false,
     requireBaseUrl: true,
     supportEmbedding: false,
-    additionalSettings: [],
+    additionalSettings: [
+      {
+        label: 'No Stainless Headers',
+        key: 'noStainless',
+        type: 'toggle',
+        required: false,
+        description:
+          'Enable this if you encounter CORS errors related to Stainless headers (x-stainless-os, etc.)',
+      },
+    ],
   },
 } as const satisfies Record<
   LLMProviderType,
@@ -141,8 +150,9 @@ export const PROVIDER_TYPES_INFO = {
     additionalSettings: {
       label: string
       key: string
-      type: 'text'
+      type: 'text' | 'toggle'
       placeholder?: string
+      description?: string
       required?: boolean
     }[]
   }

--- a/src/core/llm/NoStainlessOpenAI.ts
+++ b/src/core/llm/NoStainlessOpenAI.ts
@@ -1,0 +1,19 @@
+import OpenAI from 'openai'
+import { FinalRequestOptions } from 'openai/core'
+
+export class NoStainlessOpenAI extends OpenAI {
+  buildRequest<Req>(
+    options: FinalRequestOptions<Req>,
+    { retryCount = 0 }: { retryCount?: number } = {},
+  ): { req: RequestInit; url: string; timeout: number } {
+    const req = super.buildRequest(options, { retryCount })
+    const headers = req.req.headers as Record<string, string>
+    Object.keys(headers).forEach((k) => {
+      if (k.startsWith('x-stainless')) {
+        // eslint-disable-next-line @typescript-eslint/no-dynamic-delete
+        delete headers[k]
+      }
+    })
+    return req
+  }
+}

--- a/src/core/llm/ollama.ts
+++ b/src/core/llm/ollama.ts
@@ -3,9 +3,6 @@
  * (NoStainlessOpenAI) to work around CORS issues specific to Ollama.
  */
 
-import OpenAI from 'openai'
-import { FinalRequestOptions } from 'openai/core'
-
 import { ChatModel } from '../../types/chat-model.types'
 import {
   LLMOptions,
@@ -19,31 +16,8 @@ import {
 import { LLMProvider } from '../../types/provider.types'
 
 import { BaseLLMProvider } from './base'
+import { NoStainlessOpenAI } from './NoStainlessOpenAI'
 import { OpenAIMessageAdapter } from './openaiMessageAdapter'
-
-export class NoStainlessOpenAI extends OpenAI {
-  defaultHeaders() {
-    return {
-      Accept: 'application/json',
-      'Content-Type': 'application/json',
-    }
-  }
-
-  buildRequest<Req>(
-    options: FinalRequestOptions<Req>,
-    { retryCount = 0 }: { retryCount?: number } = {},
-  ): { req: RequestInit; url: string; timeout: number } {
-    const req = super.buildRequest(options, { retryCount })
-    const headers = req.req.headers as Record<string, string>
-    Object.keys(headers).forEach((k) => {
-      if (k.startsWith('x-stainless')) {
-        // eslint-disable-next-line @typescript-eslint/no-dynamic-delete
-        delete headers[k]
-      }
-    })
-    return req
-  }
-}
 
 export class OllamaProvider extends BaseLLMProvider<
   Extract<LLMProvider, { type: 'ollama' }>

--- a/src/core/llm/openaiCompatibleProvider.ts
+++ b/src/core/llm/openaiCompatibleProvider.ts
@@ -14,6 +14,7 @@ import { LLMProvider } from '../../types/provider.types'
 
 import { BaseLLMProvider } from './base'
 import { LLMBaseUrlNotSetException } from './exception'
+import { NoStainlessOpenAI } from './NoStainlessOpenAI'
 import { OpenAIMessageAdapter } from './openaiMessageAdapter'
 
 export class OpenAICompatibleProvider extends BaseLLMProvider<
@@ -25,7 +26,9 @@ export class OpenAICompatibleProvider extends BaseLLMProvider<
   constructor(provider: Extract<LLMProvider, { type: 'openai-compatible' }>) {
     super(provider)
     this.adapter = new OpenAIMessageAdapter()
-    this.client = new OpenAI({
+    this.client = new (
+      provider.additionalSettings?.noStainless ? NoStainlessOpenAI : OpenAI
+    )({
       apiKey: provider.apiKey ?? '',
       baseURL: provider.baseUrl ? provider.baseUrl?.replace(/\/+$/, '') : '',
       dangerouslyAllowBrowser: true,

--- a/src/types/provider.types.ts
+++ b/src/types/provider.types.ts
@@ -64,6 +64,11 @@ export const llmProviderSchema = z.discriminatedUnion('type', [
         required_error: 'base URL is required',
       })
       .min(1, 'base URL is required'),
+    additionalSettings: z
+      .object({
+        noStainless: z.boolean().optional(),
+      })
+      .optional(),
   }),
 ])
 


### PR DESCRIPTION
## Description

Added "no stainless headers" setting for openai compatible providers.
It'll resolve https://github.com/glowingjade/obsidian-smart-composer/issues/158

## Checklist before requesting a review
- [x] I have reviewed the [guidelines for contributing](../CONTRIBUTING.md) to this repository.
- [x] I have performed a self-review of my code
- [x] I have performed a code linting check and type check (by running `npm run lint:check` and `npm run type:check`)
