### PR TITLE
feat: Added an option to enable/disable chat models.

### DIFF
--- a/src/components/chat-view/chat-input/ModelSelect.tsx
+++ b/src/components/chat-view/chat-input/ModelSelect.tsx
@@ -21,20 +21,22 @@ export function ModelSelect() {
       <DropdownMenu.Portal>
         <DropdownMenu.Content className="smtcmp-popover">
           <ul>
-            {settings.chatModels.map((chatModelOption) => (
-              <DropdownMenu.Item
-                key={chatModelOption.id}
-                onSelect={() => {
-                  setSettings({
-                    ...settings,
-                    chatModelId: chatModelOption.id,
-                  })
-                }}
-                asChild
-              >
-                <li>{chatModelOption.id}</li>
-              </DropdownMenu.Item>
-            ))}
+            {settings.chatModels
+              .filter(({ enable }) => enable ?? true)
+              .map((chatModelOption) => (
+                <DropdownMenu.Item
+                  key={chatModelOption.id}
+                  onSelect={() => {
+                    setSettings({
+                      ...settings,
+                      chatModelId: chatModelOption.id,
+                    })
+                  }}
+                  asChild
+                >
+                  <li>{chatModelOption.id}</li>
+                </DropdownMenu.Item>
+              ))}
           </ul>
         </DropdownMenu.Content>
       </DropdownMenu.Portal>

--- a/src/components/settings/sections/ChatSection.tsx
+++ b/src/components/settings/sections/ChatSection.tsx
@@ -21,10 +21,12 @@ export function ChatSection() {
         <ObsidianDropdown
           value={settings.chatModelId}
           options={Object.fromEntries(
-            settings.chatModels.map((chatModel) => [
-              chatModel.id,
-              `${chatModel.id}${RECOMMENDED_MODELS_FOR_CHAT.includes(chatModel.id) ? ' (Recommended)' : ''}`,
-            ]),
+            settings.chatModels
+              .filter(({ enable }) => enable ?? true)
+              .map((chatModel) => [
+                chatModel.id,
+                `${chatModel.id}${RECOMMENDED_MODELS_FOR_CHAT.includes(chatModel.id) ? ' (Recommended)' : ''}`,
+              ]),
           )}
           onChange={async (value) => {
             await setSettings({
@@ -42,10 +44,12 @@ export function ChatSection() {
         <ObsidianDropdown
           value={settings.applyModelId}
           options={Object.fromEntries(
-            settings.chatModels.map((chatModel) => [
-              chatModel.id,
-              `${chatModel.id}${RECOMMENDED_MODELS_FOR_APPLY.includes(chatModel.id) ? ' (Recommended)' : ''}`,
-            ]),
+            settings.chatModels
+              .filter(({ enable }) => enable ?? true)
+              .map((chatModel) => [
+                chatModel.id,
+                `${chatModel.id}${RECOMMENDED_MODELS_FOR_APPLY.includes(chatModel.id) ? ' (Recommended)' : ''}`,
+              ]),
           )}
           onChange={async (value) => {
             await setSettings({

--- a/src/components/settings/sections/ProvidersSection.tsx
+++ b/src/components/settings/sections/ProvidersSection.tsx
@@ -86,6 +86,12 @@ export function ProvidersSection({ app, plugin }: ProvidersSectionProps) {
 
       <div className="smtcmp-settings-table-container">
         <table className="smtcmp-settings-table">
+          <colgroup>
+            <col />
+            <col />
+            <col />
+            <col width={60} />
+          </colgroup>
           <thead>
             <tr>
               <th>ID</th>

--- a/src/components/settings/sections/models/ChatModelsSubSection.tsx
+++ b/src/components/settings/sections/models/ChatModelsSubSection.tsx
@@ -1,6 +1,6 @@
-import clsx from 'clsx'
 import { Trash2 } from 'lucide-react'
 import { App, Notice } from 'obsidian'
+import { ObsidianToggle } from 'src/components/common/ObsidianToggle'
 
 import { DEFAULT_CHAT_MODELS } from '../../../../constants'
 import { useSettings } from '../../../../contexts/settings-context'
@@ -34,11 +34,14 @@ export function ChatModelsSubSection({
     })
   }
 
-  const handleToggleEnableChatModel = async (modelId: string) => {
+  const handleToggleEnableChatModel = async (
+    modelId: string,
+    value: boolean,
+  ) => {
     await setSettings({
       ...settings,
       chatModels: [...settings.chatModels].map((v) =>
-        v.id === modelId ? { ...v, enable: !isEnabled(v.enable) } : v,
+        v.id === modelId ? { ...v, enable: value } : v,
       ),
     })
   }
@@ -73,17 +76,12 @@ export function ChatModelsSubSection({
                 <td>{chatModel.providerId}</td>
                 <td>{chatModel.model}</td>
                 <td>
-                  <div
-                    className={clsx('checkbox-container', {
-                      'is-enabled': isEnabled(chatModel.enable),
-                    })}
-                    onClick={() => handleToggleEnableChatModel(chatModel.id)}
-                  >
-                    <input
-                      type="checkbox"
-                      checked={isEnabled(chatModel.enable)}
-                    />
-                  </div>
+                  <ObsidianToggle
+                    value={isEnabled(chatModel.enable)}
+                    onChange={(value) =>
+                      handleToggleEnableChatModel(chatModel.id, value)
+                    }
+                  />
                 </td>
                 <td>
                   <div className="smtcmp-settings-actions">

--- a/src/components/settings/sections/models/ChatModelsSubSection.tsx
+++ b/src/components/settings/sections/models/ChatModelsSubSection.tsx
@@ -1,3 +1,4 @@
+import clsx from 'clsx'
 import { Trash2 } from 'lucide-react'
 import { App, Notice } from 'obsidian'
 
@@ -31,6 +32,15 @@ export function ChatModelsSubSection({
     })
   }
 
+  const handleToggleEnableChatModel = async (modelId: string) => {
+    await setSettings({
+      ...settings,
+      chatModels: [...settings.chatModels].map((v) =>
+        v.id === modelId ? { ...v, enable: !(v.enable ?? true) } : v,
+      ),
+    })
+  }
+
   return (
     <div>
       <div className="smtcmp-settings-sub-header">Chat Models</div>
@@ -43,6 +53,7 @@ export function ChatModelsSubSection({
               <th>ID</th>
               <th>Provider ID</th>
               <th>Model</th>
+              <th>Enable</th>
               <th>Actions</th>
             </tr>
           </thead>
@@ -52,6 +63,19 @@ export function ChatModelsSubSection({
                 <td>{chatModel.id}</td>
                 <td>{chatModel.providerId}</td>
                 <td>{chatModel.model}</td>
+                <td>
+                  <div
+                    className={clsx('checkbox-container', {
+                      'is-enabled': chatModel.enable ?? true,
+                    })}
+                    onClick={() => handleToggleEnableChatModel(chatModel.id)}
+                  >
+                    <input
+                      type="checkbox"
+                      checked={chatModel.enable ?? true}
+                    />
+                  </div>
+                </td>
                 <td>
                   <div className="smtcmp-settings-actions">
                     {!DEFAULT_CHAT_MODELS.some(

--- a/src/components/settings/sections/models/ChatModelsSubSection.tsx
+++ b/src/components/settings/sections/models/ChatModelsSubSection.tsx
@@ -50,6 +50,13 @@ export function ChatModelsSubSection({
 
       <div className="smtcmp-settings-table-container">
         <table className="smtcmp-settings-table">
+          <colgroup>
+            <col />
+            <col />
+            <col />
+            <col width={60} />
+            <col width={60} />
+          </colgroup>
           <thead>
             <tr>
               <th>ID</th>
@@ -96,7 +103,7 @@ export function ChatModelsSubSection({
           </tbody>
           <tfoot>
             <tr>
-              <td colSpan={4}>
+              <td colSpan={5}>
                 <button
                   onClick={() => {
                     new AddChatModelModal(app, plugin).open()

--- a/src/components/settings/sections/models/ChatModelsSubSection.tsx
+++ b/src/components/settings/sections/models/ChatModelsSubSection.tsx
@@ -12,6 +12,8 @@ type ChatModelsSubSectionProps = {
   plugin: SmartComposerPlugin
 }
 
+const isEnabled = (enable: boolean | undefined | null) => enable ?? true
+
 export function ChatModelsSubSection({
   app,
   plugin,
@@ -36,7 +38,7 @@ export function ChatModelsSubSection({
     await setSettings({
       ...settings,
       chatModels: [...settings.chatModels].map((v) =>
-        v.id === modelId ? { ...v, enable: !(v.enable ?? true) } : v,
+        v.id === modelId ? { ...v, enable: !isEnabled(v.enable) } : v,
       ),
     })
   }
@@ -66,13 +68,13 @@ export function ChatModelsSubSection({
                 <td>
                   <div
                     className={clsx('checkbox-container', {
-                      'is-enabled': chatModel.enable ?? true,
+                      'is-enabled': isEnabled(chatModel.enable),
                     })}
                     onClick={() => handleToggleEnableChatModel(chatModel.id)}
                   >
                     <input
                       type="checkbox"
-                      checked={chatModel.enable ?? true}
+                      checked={isEnabled(chatModel.enable)}
                     />
                   </div>
                 </td>

--- a/src/components/settings/sections/models/ChatModelsSubSection.tsx
+++ b/src/components/settings/sections/models/ChatModelsSubSection.tsx
@@ -38,6 +38,16 @@ export function ChatModelsSubSection({
     modelId: string,
     value: boolean,
   ) => {
+    if (
+      !value &&
+      (modelId === settings.chatModelId || modelId === settings.applyModelId)
+    ) {
+      new Notice(
+        'Cannot disable model that is currently selected as Chat Model or Apply Model',
+      )
+      return false
+    }
+
     await setSettings({
       ...settings,
       chatModels: [...settings.chatModels].map((v) =>

--- a/src/types/chat-model.types.ts
+++ b/src/types/chat-model.types.ts
@@ -16,6 +16,7 @@ const baseChatModelSchema = z.object({
       required_error: 'model is required',
     })
     .min(1, 'model is required'),
+  enable: z.boolean().default(true).optional(),
 })
 
 export const chatModelSchema = z.discriminatedUnion('providerType', [


### PR DESCRIPTION
## Description

A new feature has been added to allow users to turn chat models on or off as needed.

Users can toggle the enable button in the settings to switch the chat model between enabled and disabled states.

<img width="778" alt="스크린샷 2025-02-09 오후 12 22 10" src="https://github.com/user-attachments/assets/68822d69-e9c9-4914-9c3b-0f4fa75daf52" />


## Checklist before requesting a review
- [x] I have reviewed the [guidelines for contributing](../CONTRIBUTING.md) to this repository.
- [x] I have performed a self-review of my code
- [x] I have performed a code linting check and type check (by running `npm run lint:check` and `npm run type:check`)
