### PR TITLE
handle null bytes in chunk content on RAG indexing and throw error

### DIFF
--- a/src/database/modules/vector/VectorManager.ts
+++ b/src/database/modules/vector/VectorManager.ts
@@ -109,8 +109,12 @@ export class VectorManager {
         filesToIndex.map(async (file) => {
           try {
             const fileContent = await this.app.vault.cachedRead(file)
+            // Remove null bytes from the content
+            // eslint-disable-next-line no-control-regex
+            const sanitizedContent = fileContent.replace(/\x00/g, '')
+
             const fileDocuments = await textSplitter.createDocuments([
-              fileContent,
+              sanitizedContent,
             ])
             return fileDocuments.map(
               (chunk): Omit<InsertEmbedding, 'model' | 'dimension'> => {
@@ -164,6 +168,7 @@ Error details:
                     )
                   }
                   if (chunk.content.includes('\x00')) {
+                    // this should never happen because we remove null bytes from the content
                     throw new Error(
                       `Chunk content contains null bytes in file: ${chunk.path}`,
                     )

--- a/src/database/modules/vector/VectorManager.ts
+++ b/src/database/modules/vector/VectorManager.ts
@@ -158,6 +158,17 @@ Error details:
             try {
               return await backOff(
                 async () => {
+                  if (chunk.content.length === 0) {
+                    throw new Error(
+                      `Chunk content is empty in file: ${chunk.path}`,
+                    )
+                  }
+                  if (chunk.content.includes('\x00')) {
+                    throw new Error(
+                      `Chunk content contains null bytes in file: ${chunk.path}`,
+                    )
+                  }
+
                   const embedding = await embeddingModel.getEmbedding(
                     chunk.content,
                   )


### PR DESCRIPTION
## Description

handle null bytes in chunk content on RAG indexing and throw error

## Checklist before requesting a review
- [x] I have reviewed the [guidelines for contributing](../CONTRIBUTING.md) to this repository.
- [x] I have performed a self-review of my code
- [x] I have performed a code linting check and type check (by running `npm run lint:check` and `npm run type:check`)
