### PR TITLE
fix bug: interference with decimal input in RAG > Minimum Similarity settings

### DIFF
--- a/src/components/settings/sections/RAGSection.tsx
+++ b/src/components/settings/sections/RAGSection.tsx
@@ -170,6 +170,12 @@ export function RAGSection({ app, plugin }: RAGSectionProps) {
           value={String(settings.ragOptions.minSimilarity)}
           placeholder="0.0"
           onChange={async (value) => {
+            // Allow decimal point and numbers only
+            if (!/^[0-9.]*$/.test(value)) return
+
+            // Ignore typing decimal point to prevent interference with the input
+            if (value === '.' || value.endsWith('.')) return
+
             const minSimilarity = parseFloat(value)
             if (!isNaN(minSimilarity)) {
               await setSettings({


### PR DESCRIPTION
## Description

fixes https://github.com/glowingjade/obsidian-smart-composer/issues/261

## Checklist before requesting a review
- [x] I have reviewed the [guidelines for contributing](../CONTRIBUTING.md) to this repository.
- [x] I have performed a self-review of my code
- [x] I have performed a code linting check and type check (by running `npm run lint:check` and `npm run type:check`)
