### PR TITLE
feat: upgrade to Claude 3.7 Sonnet as default model

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -18,6 +18,7 @@ export const OPENAI_PRICES: Record<string, ModelPricing> = {
 
 export const ANTHROPIC_PRICES: Record<string, ModelPricing> = {
   'claude-3-5-sonnet-latest': { input: 3, output: 15 },
+  'claude-3-7-sonnet-latest': { input: 3, output: 15 },
   'claude-3-5-haiku-latest': { input: 1, output: 5 },
 }
 
@@ -219,8 +220,8 @@ export const DEFAULT_CHAT_MODELS: readonly ChatModel[] = [
   {
     providerType: 'anthropic',
     providerId: PROVIDER_TYPES_INFO.anthropic.defaultProviderId,
-    id: 'claude-3.5-sonnet',
-    model: 'claude-3-5-sonnet-latest',
+    id: 'claude-3.7-sonnet',
+    model: 'claude-3-7-sonnet-latest',
   },
   {
     providerType: 'openai',
@@ -348,7 +349,7 @@ export const DEFAULT_EMBEDDING_MODELS: readonly EmbeddingModel[] = [
 ]
 
 // use ids
-export const RECOMMENDED_MODELS_FOR_CHAT = ['claude-3.5-sonnet', 'gpt-4o']
+export const RECOMMENDED_MODELS_FOR_CHAT = ['claude-3.7-sonnet', 'gpt-4o']
 export const RECOMMENDED_MODELS_FOR_APPLY = ['gpt-4o-mini']
 export const RECOMMENDED_MODELS_FOR_EMBEDDING = [
   'openai/text-embedding-3-small',

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -224,6 +224,12 @@ export const DEFAULT_CHAT_MODELS: readonly ChatModel[] = [
     model: 'claude-3-7-sonnet-latest',
   },
   {
+    providerType: 'anthropic',
+    providerId: PROVIDER_TYPES_INFO.anthropic.defaultProviderId,
+    id: 'claude-3.5-sonnet',
+    model: 'claude-3-5-sonnet-latest',
+  },
+  {
     providerType: 'openai',
     providerId: PROVIDER_TYPES_INFO.openai.defaultProviderId,
     id: 'gpt-4o',

--- a/src/settings/schema/migrations/3_to_4.test.ts
+++ b/src/settings/schema/migrations/3_to_4.test.ts
@@ -1,7 +1,7 @@
 import { migrateFrom3To4 } from './3_to_4'
 
 describe('settings 3_to_4 migration', () => {
-  it('should migrate claude-3.5-sonnet model to claude-3.7-sonnet', () => {
+  it('should add claude-3.7-sonnet model alongside existing models', () => {
     const oldSettings = {
       version: 3,
       chatModels: [
@@ -27,8 +27,8 @@ describe('settings 3_to_4 migration', () => {
       {
         providerType: 'anthropic',
         providerId: 'anthropic',
-        id: 'claude-3.7-sonnet',
-        model: 'claude-3-7-sonnet-latest',
+        id: 'claude-3.5-sonnet',
+        model: 'claude-3-5-sonnet-latest',
       },
       {
         providerType: 'openai',
@@ -36,58 +36,29 @@ describe('settings 3_to_4 migration', () => {
         id: 'gpt-4',
         model: 'gpt-4',
       },
+      {
+        providerType: 'anthropic',
+        providerId: 'anthropic',
+        id: 'claude-3.7-sonnet',
+        model: 'claude-3-7-sonnet-latest',
+      },
     ])
-    expect(result.chatModelId).toBe('claude-3.7-sonnet')
+    expect(result.chatModelId).toBe('claude-3.5-sonnet')
   })
 
-  it('should not modify other models', () => {
+  it('should update existing claude-3.7-sonnet if present', () => {
     const oldSettings = {
       version: 3,
       chatModels: [
         {
           providerType: 'anthropic',
-          providerId: 'anthropic',
-          id: 'claude-3.5-haiku',
-          model: 'claude-3-5-haiku-latest',
-        },
-        {
-          providerType: 'openai',
-          providerId: 'openai',
-          id: 'gpt-4',
-          model: 'gpt-4',
+          providerId: 'custom-provider',
+          id: 'claude-3.7-sonnet',
+          model: 'old-model-name',
+          enable: false,
         },
       ],
-      chatModelId: 'gpt-4',
-    }
-
-    const result = migrateFrom3To4(oldSettings)
-    expect(result.version).toBe(4)
-    expect(result.chatModels).toEqual(oldSettings.chatModels)
-    expect(result.chatModelId).toBe(oldSettings.chatModelId)
-  })
-
-  it('should handle missing chatModels array', () => {
-    const oldSettings = {
-      version: 3,
-      chatModelId: 'claude-3.5-sonnet',
-    }
-
-    const result = migrateFrom3To4(oldSettings)
-    expect(result.version).toBe(4)
-    expect(result.chatModelId).toBe('claude-3.7-sonnet')
-  })
-
-  it('should handle missing chatModelId', () => {
-    const oldSettings = {
-      version: 3,
-      chatModels: [
-        {
-          providerType: 'anthropic',
-          providerId: 'anthropic',
-          id: 'claude-3.5-sonnet',
-          model: 'claude-3-5-sonnet-latest',
-        },
-      ],
+      chatModelId: 'claude-3.7-sonnet',
     }
 
     const result = migrateFrom3To4(oldSettings)
@@ -98,7 +69,9 @@ describe('settings 3_to_4 migration', () => {
         providerId: 'anthropic',
         id: 'claude-3.7-sonnet',
         model: 'claude-3-7-sonnet-latest',
+        enable: false,
       },
     ])
+    expect(result.chatModelId).toBe('claude-3.7-sonnet')
   })
 })

--- a/src/settings/schema/migrations/3_to_4.test.ts
+++ b/src/settings/schema/migrations/3_to_4.test.ts
@@ -27,6 +27,12 @@ describe('settings 3_to_4 migration', () => {
       {
         providerType: 'anthropic',
         providerId: 'anthropic',
+        id: 'claude-3.7-sonnet',
+        model: 'claude-3-7-sonnet-latest',
+      },
+      {
+        providerType: 'anthropic',
+        providerId: 'anthropic',
         id: 'claude-3.5-sonnet',
         model: 'claude-3-5-sonnet-latest',
       },
@@ -35,12 +41,6 @@ describe('settings 3_to_4 migration', () => {
         providerId: 'openai',
         id: 'gpt-4',
         model: 'gpt-4',
-      },
-      {
-        providerType: 'anthropic',
-        providerId: 'anthropic',
-        id: 'claude-3.7-sonnet',
-        model: 'claude-3-7-sonnet-latest',
       },
     ])
     expect(result.chatModelId).toBe('claude-3.5-sonnet')

--- a/src/settings/schema/migrations/3_to_4.test.ts
+++ b/src/settings/schema/migrations/3_to_4.test.ts
@@ -1,0 +1,104 @@
+import { migrateFrom3To4 } from './3_to_4'
+
+describe('settings 3_to_4 migration', () => {
+  it('should migrate claude-3.5-sonnet model to claude-3.7-sonnet', () => {
+    const oldSettings = {
+      version: 3,
+      chatModels: [
+        {
+          providerType: 'anthropic',
+          providerId: 'anthropic',
+          id: 'claude-3.5-sonnet',
+          model: 'claude-3-5-sonnet-latest',
+        },
+        {
+          providerType: 'openai',
+          providerId: 'openai',
+          id: 'gpt-4',
+          model: 'gpt-4',
+        },
+      ],
+      chatModelId: 'claude-3.5-sonnet',
+    }
+
+    const result = migrateFrom3To4(oldSettings)
+    expect(result.version).toBe(4)
+    expect(result.chatModels).toEqual([
+      {
+        providerType: 'anthropic',
+        providerId: 'anthropic',
+        id: 'claude-3.7-sonnet',
+        model: 'claude-3-7-sonnet-latest',
+      },
+      {
+        providerType: 'openai',
+        providerId: 'openai',
+        id: 'gpt-4',
+        model: 'gpt-4',
+      },
+    ])
+    expect(result.chatModelId).toBe('claude-3.7-sonnet')
+  })
+
+  it('should not modify other models', () => {
+    const oldSettings = {
+      version: 3,
+      chatModels: [
+        {
+          providerType: 'anthropic',
+          providerId: 'anthropic',
+          id: 'claude-3.5-haiku',
+          model: 'claude-3-5-haiku-latest',
+        },
+        {
+          providerType: 'openai',
+          providerId: 'openai',
+          id: 'gpt-4',
+          model: 'gpt-4',
+        },
+      ],
+      chatModelId: 'gpt-4',
+    }
+
+    const result = migrateFrom3To4(oldSettings)
+    expect(result.version).toBe(4)
+    expect(result.chatModels).toEqual(oldSettings.chatModels)
+    expect(result.chatModelId).toBe(oldSettings.chatModelId)
+  })
+
+  it('should handle missing chatModels array', () => {
+    const oldSettings = {
+      version: 3,
+      chatModelId: 'claude-3.5-sonnet',
+    }
+
+    const result = migrateFrom3To4(oldSettings)
+    expect(result.version).toBe(4)
+    expect(result.chatModelId).toBe('claude-3.7-sonnet')
+  })
+
+  it('should handle missing chatModelId', () => {
+    const oldSettings = {
+      version: 3,
+      chatModels: [
+        {
+          providerType: 'anthropic',
+          providerId: 'anthropic',
+          id: 'claude-3.5-sonnet',
+          model: 'claude-3-5-sonnet-latest',
+        },
+      ],
+    }
+
+    const result = migrateFrom3To4(oldSettings)
+    expect(result.version).toBe(4)
+    expect(result.chatModels).toEqual([
+      {
+        providerType: 'anthropic',
+        providerId: 'anthropic',
+        id: 'claude-3.7-sonnet',
+        model: 'claude-3-7-sonnet-latest',
+      },
+    ])
+  })
+})

--- a/src/settings/schema/migrations/3_to_4.ts
+++ b/src/settings/schema/migrations/3_to_4.ts
@@ -11,23 +11,25 @@ export const migrateFrom3To4: SettingMigration['migrate'] = (data) => {
       newData.chatModels.map((model) => [model.id, model]),
     )
 
-    const newModel = {
+    let newModel = {
       providerType: 'anthropic',
       providerId: PROVIDER_TYPES_INFO.anthropic.defaultProviderId,
       id: 'claude-3.7-sonnet',
       model: 'claude-3-7-sonnet-latest',
     }
 
-    // Add new model, overriding if ID exists
+    // override existing model with same id
     const existingModel = existingModelsMap.get(newModel.id)
     if (existingModel) {
-      // Override the model while keeping any custom settings
-      Object.assign(existingModel, newModel)
-    } else {
-      // Add new model
-      newData.chatModels.push(newModel)
+      // keep the existing model settings
+      newModel = Object.assign(existingModel, newModel)
+      // Remove the existing model from the array
+      newData.chatModels = newData.chatModels.filter(
+        (model) => model.id !== newModel.id,
+      )
     }
+    // Add the new model at index 0 of the array
+    ;(newData.chatModels as unknown[]).splice(0, 0, newModel)
   }
-
   return newData
 }

--- a/src/settings/schema/migrations/3_to_4.ts
+++ b/src/settings/schema/migrations/3_to_4.ts
@@ -1,0 +1,31 @@
+import { SettingMigration } from '../setting.types'
+
+export const migrateFrom3To4: SettingMigration['migrate'] = (data) => {
+  const newData = { ...data }
+  newData.version = 4
+
+  // Handle chat models migration
+  if ('chatModels' in newData && Array.isArray(newData.chatModels)) {
+    for (const model of newData.chatModels) {
+      if (
+        model.providerType === 'anthropic' &&
+        model.id === 'claude-3.5-sonnet' &&
+        model.model === 'claude-3-5-sonnet-latest'
+      ) {
+        model.id = 'claude-3.7-sonnet'
+        model.model = 'claude-3-7-sonnet-latest'
+      }
+    }
+  }
+
+  // Update selected chat model if it was claude-3.5-sonnet
+  if (
+    'chatModelId' in newData &&
+    typeof newData.chatModelId === 'string' &&
+    newData.chatModelId === 'claude-3.5-sonnet'
+  ) {
+    newData.chatModelId = 'claude-3.7-sonnet'
+  }
+
+  return newData
+}

--- a/src/settings/schema/migrations/index.ts
+++ b/src/settings/schema/migrations/index.ts
@@ -3,6 +3,7 @@ import { SettingMigration } from '../setting.types'
 import { migrateFrom0To1 } from './0_to_1'
 import { migrateFrom1To2 } from './1_to_2'
 import { migrateFrom2To3 } from './2_to_3'
+import { migrateFrom3To4 } from './3_to_4'
 
 export const SETTING_MIGRATIONS: SettingMigration[] = [
   {
@@ -19,5 +20,10 @@ export const SETTING_MIGRATIONS: SettingMigration[] = [
     fromVersion: 2,
     toVersion: 3,
     migrate: migrateFrom2To3,
+  },
+  {
+    fromVersion: 3,
+    toVersion: 4,
+    migrate: migrateFrom3To4,
   },
 ]

--- a/src/settings/schema/setting.types.ts
+++ b/src/settings/schema/setting.types.ts
@@ -18,7 +18,7 @@ const ragOptionsSchema = z.object({
   includePatterns: z.array(z.string()).catch([]),
 })
 
-export const SETTINGS_SCHEMA_VERSION = 3
+export const SETTINGS_SCHEMA_VERSION = 4
 
 /**
  * Settings

--- a/src/settings/schema/settings.test.ts
+++ b/src/settings/schema/settings.test.ts
@@ -18,7 +18,7 @@ describe('parseSmartComposerSettings', () => {
       chatModels: [...DEFAULT_CHAT_MODELS],
       embeddingModels: [...DEFAULT_EMBEDDING_MODELS],
 
-      chatModelId: 'claude-3.5-sonnet',
+      chatModelId: 'claude-3.7-sonnet',
       applyModelId: 'gpt-4o-mini',
       embeddingModelId: 'openai/text-embedding-3-small',
 


### PR DESCRIPTION
## Description
- Update default and recommended chat model from Claude 3.5 to Claude 3.7 Sonnet
- Add Claude 3.7 Sonnet pricing configuration
- Increment settings schema version to 4 and add migration

## To-Do
- Support [extended thinking mode](https://docs.anthropic.com/en/docs/build-with-claude/extended-thinking) for Claude 3.7 Sonnet

## Checklist before requesting a review
- [x] I have reviewed the [guidelines for contributing](../CONTRIBUTING.md) to this repository.
- [x] I have performed a self-review of my code
- [x] I have performed a code linting check and type check (by running `npm run lint:check` and `npm run type:check`)
