### PR TITLE
Claude 3.7 Sonnet Thinking Integration

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.1.14",
       "license": "MIT",
       "dependencies": {
-        "@anthropic-ai/sdk": "^0.27.3",
+        "@anthropic-ai/sdk": "^0.39.0",
         "@electric-sql/pglite": "0.2.12",
         "@google/generative-ai": "^0.21.0",
         "@lexical/clipboard": "^0.17.1",
@@ -85,8 +85,9 @@
       }
     },
     "node_modules/@anthropic-ai/sdk": {
-      "version": "0.27.3",
-      "license": "MIT",
+      "version": "0.39.0",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/sdk/-/sdk-0.39.0.tgz",
+      "integrity": "sha512-eMyDIPRZbt1CCLErRCi3exlAvNkBtRe+kW5vvJyef93PmNr/clstYgHhtvmkxN82nlKgzyGPCyGxrm0JQ1ZIdg==",
       "dependencies": {
         "@types/node": "^18.11.18",
         "@types/node-fetch": "^2.6.4",

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "typescript": "^5.6.2"
   },
   "dependencies": {
-    "@anthropic-ai/sdk": "^0.27.3",
+    "@anthropic-ai/sdk": "^0.39.0",
     "@electric-sql/pglite": "0.2.12",
     "@google/generative-ai": "^0.21.0",
     "@lexical/clipboard": "^0.17.1",

--- a/src/components/chat-view/AssistantMessageReasoning.tsx
+++ b/src/components/chat-view/AssistantMessageReasoning.tsx
@@ -1,0 +1,61 @@
+import { ChevronDown, ChevronUp } from 'lucide-react'
+import { useEffect, useRef, useState } from 'react'
+import Markdown from 'react-markdown'
+
+export default function AssistantMessageReasoning({
+  reasoning,
+}: {
+  reasoning: string
+}) {
+  const [isExpanded, setIsExpanded] = useState(false)
+  const [showLoader, setShowLoader] = useState(false)
+  const previousReasoning = useRef(reasoning)
+  const hasUserInteracted = useRef(false)
+
+  useEffect(() => {
+    if (
+      previousReasoning.current !== reasoning &&
+      previousReasoning.current !== ''
+    ) {
+      setShowLoader(true)
+      if (!hasUserInteracted.current) {
+        setIsExpanded(true)
+      }
+      const timer = setTimeout(() => {
+        setShowLoader(false)
+      }, 1000)
+      return () => clearTimeout(timer)
+    }
+    previousReasoning.current = reasoning
+  }, [reasoning])
+
+  const handleToggle = () => {
+    hasUserInteracted.current = true
+    setIsExpanded(!isExpanded)
+  }
+
+  return (
+    <div className="smtcmp-assistant-message-reasoning">
+      <div
+        className="smtcmp-assistant-message-reasoning-toggle"
+        onClick={handleToggle}
+      >
+        <span>Reasoning {showLoader && <DotLoader />}</span>
+        {isExpanded ? (
+          <ChevronUp className="smtcmp-assistant-message-reasoning-toggle-icon" />
+        ) : (
+          <ChevronDown className="smtcmp-assistant-message-reasoning-toggle-icon" />
+        )}
+      </div>
+      {isExpanded && (
+        <div className="smtcmp-assistant-message-reasoning-content">
+          <Markdown className="smtcmp-markdown">{reasoning}</Markdown>
+        </div>
+      )}
+    </div>
+  )
+}
+
+function DotLoader() {
+  return <span className="smtcmp-dot-loader" aria-label="Loading"></span>
+}

--- a/src/components/chat-view/ReactMarkdown.tsx
+++ b/src/components/chat-view/ReactMarkdown.tsx
@@ -1,6 +1,7 @@
-import React, { useMemo } from 'react'
+import React, { useCallback, useMemo } from 'react'
 import Markdown from 'react-markdown'
 
+import { ChatMessage } from '../../types/chat'
 import {
   ParsedSmtcmpBlock,
   parsesmtcmpBlocks,
@@ -9,7 +10,7 @@ import {
 import MarkdownCodeComponent from './MarkdownCodeComponent'
 import MarkdownReferenceBlock from './MarkdownReferenceBlock'
 
-function ReactMarkdown({
+const ReactMarkdown = React.memo(function ReactMarkdown({
   onApply,
   isApplying,
   children,
@@ -51,6 +52,31 @@ function ReactMarkdown({
       )}
     </>
   )
-}
+})
 
-export default React.memo(ReactMarkdown)
+export function ReactMarkdownItem({
+  index,
+  chatMessages,
+  handleApply,
+  isApplying,
+  children,
+}: {
+  index: number
+  chatMessages: ChatMessage[]
+  handleApply: (blockToApply: string, chatMessages: ChatMessage[]) => void
+  isApplying: boolean
+  children: string
+}) {
+  const onApply = useCallback(
+    (blockToApply: string) => {
+      handleApply(blockToApply, chatMessages.slice(0, index + 1))
+    },
+    [handleApply, chatMessages, index],
+  )
+
+  return (
+    <ReactMarkdown onApply={onApply} isApplying={isApplying}>
+      {children}
+    </ReactMarkdown>
+  )
+}

--- a/src/components/settings/ClaudeThinkingSettingsModalRoot.tsx
+++ b/src/components/settings/ClaudeThinkingSettingsModalRoot.tsx
@@ -60,8 +60,8 @@ function ClaudeThinkingSettingsModalRoot({
 }) {
   const [budgetTokens, setBudgetTokens] = useState(
     model.providerType === 'anthropic'
-      ? (model.thinking?.budget_tokens ?? 0).toString()
-      : '0',
+      ? (model.thinking?.budget_tokens ?? 8192).toString()
+      : '8192',
   )
 
   const handleSubmit = async () => {

--- a/src/components/settings/ClaudeThinkingSettingsModalRoot.tsx
+++ b/src/components/settings/ClaudeThinkingSettingsModalRoot.tsx
@@ -1,0 +1,125 @@
+import { App, Modal, Notice } from 'obsidian'
+import { useState } from 'react'
+import { createRoot } from 'react-dom/client'
+
+import SmartComposerPlugin from '../../main'
+import { ChatModel, chatModelSchema } from '../../types/chat-model.types'
+import { ObsidianButton } from '../common/ObsidianButton'
+import { ObsidianSetting } from '../common/ObsidianSetting'
+import { ObsidianTextInput } from '../common/ObsidianTextInput'
+
+/**
+ * TODO: This is a temporary implementation specific to the thinking model.
+ * Future work should implement a configurable settings system for all models.
+ */
+
+export class ClaudeThinkingSettingsModal extends Modal {
+  private plugin: SmartComposerPlugin
+  private model: ChatModel
+  private root: ReturnType<typeof createRoot> | null = null
+
+  constructor(app: App, plugin: SmartComposerPlugin, model: ChatModel) {
+    super(app)
+    this.plugin = plugin
+    this.model = model
+  }
+
+  onOpen() {
+    const { contentEl } = this
+    contentEl.empty()
+    this.titleEl.setText('Edit Chat Model: claude-3.7-sonnet-thinking')
+
+    this.root = createRoot(contentEl)
+    this.root.render(
+      <ClaudeThinkingSettingsModalRoot
+        plugin={this.plugin}
+        model={this.model}
+        onClose={() => this.close()}
+      />,
+    )
+  }
+
+  onClose() {
+    if (this.root) {
+      this.root.unmount()
+      this.root = null
+    }
+    const { contentEl } = this
+    contentEl.empty()
+  }
+}
+
+function ClaudeThinkingSettingsModalRoot({
+  plugin,
+  model,
+  onClose,
+}: {
+  plugin: SmartComposerPlugin
+  model: ChatModel
+  onClose: () => void
+}) {
+  const [budgetTokens, setBudgetTokens] = useState(
+    model.providerType === 'anthropic'
+      ? (model.thinking?.budget_tokens ?? 0).toString()
+      : '0',
+  )
+
+  const handleSubmit = async () => {
+    if (model.providerType === 'anthropic') {
+      const parsedTokens = parseInt(budgetTokens, 10)
+      if (isNaN(parsedTokens)) {
+        new Notice('Please enter a valid number')
+        return
+      }
+
+      if (parsedTokens < 1024) {
+        new Notice('Budget tokens must be at least 1024')
+        return
+      }
+
+      const updatedModel = {
+        ...model,
+        thinking: { budget_tokens: parsedTokens },
+      }
+
+      const validationResult = chatModelSchema.safeParse(updatedModel)
+      if (!validationResult.success) {
+        new Notice(
+          validationResult.error.issues.map((v) => v.message).join('\n'),
+        )
+        return
+      }
+
+      await plugin.setSettings({
+        ...plugin.settings,
+        chatModels: plugin.settings.chatModels.map((m) =>
+          m.id === model.id ? updatedModel : m,
+        ),
+      })
+      onClose()
+    }
+  }
+
+  return (
+    <>
+      <ObsidianSetting
+        name="Budget Tokens"
+        desc="The maximum number of tokens that Claude can use for thinking."
+        required
+      >
+        <ObsidianTextInput
+          value={budgetTokens}
+          placeholder="Number of tokens"
+          onChange={(value: string) => {
+            setBudgetTokens(value)
+          }}
+        />
+      </ObsidianSetting>
+
+      <ObsidianSetting>
+        <ObsidianButton text="Save" onClick={handleSubmit} cta />
+        <ObsidianButton text="Cancel" onClick={onClose} />
+      </ObsidianSetting>
+    </>
+  )
+}

--- a/src/components/settings/sections/models/ChatModelsSubSection.tsx
+++ b/src/components/settings/sections/models/ChatModelsSubSection.tsx
@@ -1,11 +1,12 @@
-import { Trash2 } from 'lucide-react'
+import { Settings, Trash2 } from 'lucide-react'
 import { App, Notice } from 'obsidian'
 import { ObsidianToggle } from 'src/components/common/ObsidianToggle'
 
-import { DEFAULT_CHAT_MODELS } from '../../../../constants'
+import { DEFAULT_CHAT_MODELS, PROVIDER_TYPES_INFO } from '../../../../constants'
 import { useSettings } from '../../../../contexts/settings-context'
 import SmartComposerPlugin from '../../../../main'
 import { AddChatModelModal } from '../../../../settings/AddChatModelModal'
+import { ClaudeThinkingSettingsModal } from '../../ClaudeThinkingSettingsModalRoot'
 
 type ChatModelsSubSectionProps = {
   app: App
@@ -103,6 +104,26 @@ export function ChatModelsSubSection({
                 </td>
                 <td>
                   <div className="smtcmp-settings-actions">
+                    {/**
+                     * TODO: This is a temporary implementation specific to the thinking model.
+                     * Future work should implement a configurable settings system for all models.
+                     */}
+                    {chatModel.providerType === 'anthropic' &&
+                      chatModel.providerId ===
+                        PROVIDER_TYPES_INFO.anthropic.defaultProviderId &&
+                      chatModel.id === 'claude-3.7-sonnet-thinking' && (
+                        <button
+                          onClick={() => {
+                            new ClaudeThinkingSettingsModal(
+                              app,
+                              plugin,
+                              chatModel,
+                            ).open()
+                          }}
+                        >
+                          <Settings size={16} />
+                        </button>
+                      )}
                     {!DEFAULT_CHAT_MODELS.some(
                       (v) => v.id === chatModel.id,
                     ) && (

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -226,17 +226,17 @@ export const DEFAULT_CHAT_MODELS: readonly ChatModel[] = [
   {
     providerType: 'anthropic',
     providerId: PROVIDER_TYPES_INFO.anthropic.defaultProviderId,
-    id: 'claude-3.5-sonnet',
-    model: 'claude-3-5-sonnet-latest',
-  },
-  {
-    providerType: 'anthropic',
-    providerId: PROVIDER_TYPES_INFO.anthropic.defaultProviderId,
     id: 'claude-3.7-sonnet-thinking',
     model: 'claude-3-7-sonnet-latest',
     thinking: {
       budget_tokens: 8192,
     },
+  },
+  {
+    providerType: 'anthropic',
+    providerId: PROVIDER_TYPES_INFO.anthropic.defaultProviderId,
+    id: 'claude-3.5-sonnet',
+    model: 'claude-3-5-sonnet-latest',
   },
   {
     providerType: 'openai',

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -230,6 +230,15 @@ export const DEFAULT_CHAT_MODELS: readonly ChatModel[] = [
     model: 'claude-3-5-sonnet-latest',
   },
   {
+    providerType: 'anthropic',
+    providerId: PROVIDER_TYPES_INFO.anthropic.defaultProviderId,
+    id: 'claude-3.7-sonnet-thinking',
+    model: 'claude-3-7-sonnet-latest',
+    thinking: {
+      budget_tokens: 8192,
+    },
+  },
+  {
     providerType: 'openai',
     providerId: PROVIDER_TYPES_INFO.openai.defaultProviderId,
     id: 'gpt-4o',

--- a/src/hooks/useChatHistory.ts
+++ b/src/hooks/useChatHistory.ts
@@ -142,6 +142,7 @@ const serializeChatMessage = (message: ChatMessage): SerializedChatMessage => {
       return {
         role: 'assistant',
         content: message.content,
+        reasoning: message.reasoning,
         id: message.id,
         metadata: message.metadata,
       }
@@ -169,6 +170,7 @@ const deserializeChatMessage = (
       return {
         role: 'assistant',
         content: message.content,
+        reasoning: message.reasoning,
         id: message.id,
         metadata: message.metadata,
       }

--- a/src/settings/schema/migrations/4_to_5.test.ts
+++ b/src/settings/schema/migrations/4_to_5.test.ts
@@ -1,0 +1,85 @@
+import { migrateFrom4To5 } from './4_to_5'
+
+describe('settings 4_to_5 migration', () => {
+  it('should add claude-3.7-sonnet-thinking model at index 1', () => {
+    const oldSettings = {
+      version: 4,
+      chatModels: [
+        {
+          providerType: 'anthropic',
+          providerId: 'anthropic',
+          id: 'claude-3.7-sonnet',
+          model: 'claude-3-7-sonnet-latest',
+        },
+        {
+          providerType: 'openai',
+          providerId: 'openai',
+          id: 'gpt-4',
+          model: 'gpt-4',
+        },
+      ],
+      chatModelId: 'claude-3.7-sonnet',
+    }
+
+    const result = migrateFrom4To5(oldSettings)
+    expect(result.version).toBe(5)
+    expect(result.chatModels).toEqual([
+      {
+        providerType: 'anthropic',
+        providerId: 'anthropic',
+        id: 'claude-3.7-sonnet',
+        model: 'claude-3-7-sonnet-latest',
+      },
+      {
+        providerType: 'anthropic',
+        providerId: 'anthropic',
+        id: 'claude-3.7-sonnet-thinking',
+        model: 'claude-3-7-sonnet-latest',
+        thinking: {
+          budget_tokens: 8192,
+        },
+      },
+      {
+        providerType: 'openai',
+        providerId: 'openai',
+        id: 'gpt-4',
+        model: 'gpt-4',
+      },
+    ])
+    expect(result.chatModelId).toBe('claude-3.7-sonnet')
+  })
+
+  it('should replace existing claude-3.7-sonnet-thinking with new configuration', () => {
+    const oldSettings = {
+      version: 4,
+      chatModels: [
+        {
+          providerType: 'anthropic',
+          providerId: 'custom-provider',
+          id: 'claude-3.7-sonnet-thinking',
+          model: 'old-model-name',
+          thinking: {
+            budget_tokens: 1000,
+          },
+          enable: false,
+        },
+      ],
+      chatModelId: 'claude-3.7-sonnet-thinking',
+    }
+
+    const result = migrateFrom4To5(oldSettings)
+    expect(result.version).toBe(5)
+    expect(result.chatModels).toEqual([
+      {
+        providerType: 'anthropic',
+        providerId: 'anthropic',
+        id: 'claude-3.7-sonnet-thinking',
+        model: 'claude-3-7-sonnet-latest',
+        thinking: {
+          budget_tokens: 8192,
+        },
+      },
+    ])
+    expect(result.chatModelId).toBe('claude-3.7-sonnet-thinking')
+  })
+})

--- a/src/settings/schema/migrations/4_to_5.ts
+++ b/src/settings/schema/migrations/4_to_5.ts
@@ -1,0 +1,35 @@
+import { PROVIDER_TYPES_INFO } from '../../../constants'
+import { SettingMigration } from '../setting.types'
+
+export const migrateFrom4To5: SettingMigration['migrate'] = (data) => {
+  const newData = { ...data }
+  newData.version = 5
+
+  if ('chatModels' in newData && Array.isArray(newData.chatModels)) {
+    const existingModelsMap = new Map(
+      newData.chatModels.map((model) => [model.id, model]),
+    )
+
+    const newModel = {
+      providerType: 'anthropic',
+      providerId: PROVIDER_TYPES_INFO.anthropic.defaultProviderId,
+      id: 'claude-3.7-sonnet-thinking',
+      model: 'claude-3-7-sonnet-latest',
+      thinking: {
+        budget_tokens: 8192,
+      },
+    }
+
+    // override existing model with same id
+    const existingModel = existingModelsMap.get(newModel.id)
+    if (existingModel) {
+      // Remove the existing model from the array
+      newData.chatModels = newData.chatModels.filter(
+        (model) => model.id !== newModel.id,
+      )
+    }
+    // Add the new model at index 1 of the array
+    ;(newData.chatModels as unknown[]).splice(1, 0, newModel)
+  }
+  return newData
+}

--- a/src/settings/schema/migrations/index.ts
+++ b/src/settings/schema/migrations/index.ts
@@ -4,6 +4,7 @@ import { migrateFrom0To1 } from './0_to_1'
 import { migrateFrom1To2 } from './1_to_2'
 import { migrateFrom2To3 } from './2_to_3'
 import { migrateFrom3To4 } from './3_to_4'
+import { migrateFrom4To5 } from './4_to_5'
 
 export const SETTING_MIGRATIONS: SettingMigration[] = [
   {
@@ -25,5 +26,10 @@ export const SETTING_MIGRATIONS: SettingMigration[] = [
     fromVersion: 3,
     toVersion: 4,
     migrate: migrateFrom3To4,
+  },
+  {
+    fromVersion: 4,
+    toVersion: 5,
+    migrate: migrateFrom4To5,
   },
 ]

--- a/src/settings/schema/setting.types.ts
+++ b/src/settings/schema/setting.types.ts
@@ -18,7 +18,7 @@ const ragOptionsSchema = z.object({
   includePatterns: z.array(z.string()).catch([]),
 })
 
-export const SETTINGS_SCHEMA_VERSION = 4
+export const SETTINGS_SCHEMA_VERSION = 5
 
 /**
  * Settings

--- a/src/types/chat-model.types.ts
+++ b/src/types/chat-model.types.ts
@@ -28,6 +28,11 @@ export const chatModelSchema = z.discriminatedUnion('providerType', [
   z.object({
     providerType: z.literal('anthropic'),
     ...baseChatModelSchema.shape,
+    thinking: z
+      .object({
+        budget_tokens: z.number(),
+      })
+      .optional(),
   }),
   z.object({
     providerType: z.literal('gemini'),

--- a/src/types/chat.ts
+++ b/src/types/chat.ts
@@ -20,6 +20,7 @@ export type ChatUserMessage = {
 export type ChatAssistantMessage = {
   role: 'assistant'
   content: string
+  reasoning?: string
   id: string
   metadata?: {
     usage?: ResponseUsage
@@ -41,6 +42,7 @@ export type SerializedChatUserMessage = {
 export type SerializedChatAssistantMessage = {
   role: 'assistant'
   content: string
+  reasoning?: string
   id: string
   metadata?: {
     usage?: ResponseUsage

--- a/src/types/llm/response.ts
+++ b/src/types/llm/response.ts
@@ -31,6 +31,7 @@ type NonStreamingChoice = {
   finish_reason: string | null // Depends on the model. Ex: 'stop' | 'length' | 'content_filter' | 'tool_calls' | 'function_call'
   message: {
     content: string | null
+    reasoning?: string | null
     role: string
   }
   error?: Error
@@ -39,7 +40,8 @@ type NonStreamingChoice = {
 type StreamingChoice = {
   finish_reason: string | null
   delta: {
-    content: string | null
+    content?: string | null
+    reasoning?: string | null
     role?: string
   }
   error?: Error

--- a/styles.css
+++ b/styles.css
@@ -1335,7 +1335,6 @@ button.smtcmp-chat-input-model-select {
   display: flex;
   align-items: center;
   justify-content: space-between;
-  /* border-left: 1px solid var(--background-modifier-border); */
   gap: var(--size-4-1);
   font-size: var(--font-ui-small);
   color: var(--text-muted);

--- a/styles.css
+++ b/styles.css
@@ -1317,3 +1317,40 @@ button.smtcmp-chat-input-model-select {
 .smtcmp-error-modal-buttons {
   margin-top: 1rem;
 }
+
+.smtcmp-assistant-message-reasoning {
+  display: flex;
+  flex-direction: column;
+  margin-top: var(--size-4-1);
+  border-left: 2px solid var(--background-modifier-border);
+  padding-left: var(--size-4-1);
+}
+
+.smtcmp-assistant-message-reasoning-content {
+  color: var(--text-muted);
+  padding-left: var(--size-4-1);
+}
+
+.smtcmp-assistant-message-reasoning-toggle {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  /* border-left: 1px solid var(--background-modifier-border); */
+  gap: var(--size-4-1);
+  font-size: var(--font-ui-small);
+  color: var(--text-muted);
+  background-color: transparent;
+  cursor: pointer;
+  border-radius: var(--radius-s);
+  padding: var(--size-2-3) var(--size-4-1);
+  user-select: none;
+
+  &:hover {
+    background-color: var(--background-modifier-hover);
+  }
+}
+
+.smtcmp-assistant-message-reasoning-toggle-icon {
+  width: var(--size-4-4);
+  height: var(--size-4-4);
+}


### PR DESCRIPTION
## Description

This PR integrates Claude 3.7 Sonnet's thinking feature, which provides visibility into the model's reasoning process during responses. The implementation includes:

### Changes
- Upgraded Anthropic SDK from v0.27.3 to v0.39.0 to support new thinking capabilities
- Added thinking configuration support in the Anthropic provider
- Introduced a new Claude 3.7 Sonnet model with thinking enabled by default (8192 token budget)

### UI Enhancements
- Added a new `AssistantMessageReasoning` component that displays the model's reasoning in a collapsible section
- Integrated reasoning display in the chat interface
- Implemented a dedicated settings modal for Claude thinking configuration

## Related Issues
Closes #299 

## Checklist before requesting a review
- [x] I have reviewed the [guidelines for contributing](../CONTRIBUTING.md) to this repository.
- [x] I have performed a self-review of my code
- [x] I have performed a code linting check and type check (by running `npm run lint:check` and `npm run type:check`)
- [x] I have run the test suite (by running `npm run test`)
- [x] I have tested the functionality manually


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced an interactive display that allows users to view and toggle additional reasoning details in chat messages.
  - Added a new configuration modal to adjust advanced chat model settings.
  - Enhanced message rendering to include supplementary context information.

- **Style**
  - Updated visual styling for the reasoning sections, ensuring a clear and modern layout.

- **Tests & Migration**
  - Upgraded dependencies and added migration tests for a seamless settings upgrade.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->