### PR TITLE
feat: Update default gemini models

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "@anthropic-ai/sdk": "^0.39.0",
         "@electric-sql/pglite": "0.2.12",
-        "@google/generative-ai": "^0.21.0",
+        "@google/generative-ai": "^0.24.0",
         "@lexical/clipboard": "^0.17.1",
         "@lexical/react": "^0.17.1",
         "@radix-ui/react-dialog": "^1.1.2",
@@ -1247,9 +1247,9 @@
       "license": "MIT"
     },
     "node_modules/@google/generative-ai": {
-      "version": "0.21.0",
-      "resolved": "https://registry.npmjs.org/@google/generative-ai/-/generative-ai-0.21.0.tgz",
-      "integrity": "sha512-7XhUbtnlkSEZK15kN3t+tzIMxsbKm/dSkKBFalj+20NvPKe1kBY7mR2P7vuijEn+f06z5+A8bVGKO0v39cr6Wg==",
+      "version": "0.24.0",
+      "resolved": "https://registry.npmjs.org/@google/generative-ai/-/generative-ai-0.24.0.tgz",
+      "integrity": "sha512-fnEITCGEB7NdX0BhoYZ/cq/7WPZ1QS5IzJJfC3Tg/OwkvBetMiVJciyaan297OvE4B9Jg1xvo0zIazX/9sGu1Q==",
       "engines": {
         "node": ">=18.0.0"
       }
@@ -11108,6 +11108,28 @@
       },
       "engines": {
         "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+      }
+    },
+    "node_modules/ws": {
+      "version": "8.18.1",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.1.tgz",
+      "integrity": "sha512-RKW2aJZMXeMxVpnZ6bck+RswznaxmzdULiBr6KY7XkTnW8uvt0iT9H5DkHUChXrc+uurzwa0rVI16n/Xzjdz1w==",
+      "optional": true,
+      "peer": true,
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
       }
     },
     "node_modules/xtend": {

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
   "dependencies": {
     "@anthropic-ai/sdk": "^0.39.0",
     "@electric-sql/pglite": "0.2.12",
-    "@google/generative-ai": "^0.21.0",
+    "@google/generative-ai": "^0.24.0",
     "@lexical/clipboard": "^0.17.1",
     "@lexical/react": "^0.17.1",
     "@radix-ui/react-dialog": "^1.1.2",

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -14,6 +14,9 @@ type ModelPricing = {
 export const OPENAI_PRICES: Record<string, ModelPricing> = {
   'gpt-4o': { input: 2.5, output: 10 },
   'gpt-4o-mini': { input: 0.15, output: 0.6 },
+  o1: { input: 15, output: 60 },
+  'o3-mini': { input: 1.1, output: 4.4 },
+  'o1-mini': { input: 1.1, output: 4.4 },
 }
 
 export const ANTHROPIC_PRICES: Record<string, ModelPricing> = {

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -273,14 +273,14 @@ export const DEFAULT_CHAT_MODELS: readonly ChatModel[] = [
   {
     providerType: 'gemini',
     providerId: PROVIDER_TYPES_INFO.gemini.defaultProviderId,
-    id: 'gemini-1.5-pro',
-    model: 'gemini-1.5-pro',
+    id: 'gemini-2.5-pro',
+    model: 'gemini-2.5-pro-preview-03-25',
   },
   {
     providerType: 'gemini',
     providerId: PROVIDER_TYPES_INFO.gemini.defaultProviderId,
     id: 'gemini-2.0-flash',
-    model: 'gemini-2.0-flash-exp',
+    model: 'gemini-2.0-flash',
   },
   {
     providerType: 'gemini',
@@ -291,8 +291,14 @@ export const DEFAULT_CHAT_MODELS: readonly ChatModel[] = [
   {
     providerType: 'gemini',
     providerId: PROVIDER_TYPES_INFO.gemini.defaultProviderId,
-    id: 'gemini-exp-1206',
-    model: 'gemini-exp-1206',
+    id: 'gemini-2.0-flash-lite',
+    model: 'gemini-2.0-flash-lite',
+  },
+  {
+    providerType: 'gemini',
+    providerId: PROVIDER_TYPES_INFO.gemini.defaultProviderId,
+    id: 'gemini-1.5-pro',
+    model: 'gemini-1.5-pro',
   },
   {
     providerType: 'gemini',

--- a/src/core/llm/gemini.ts
+++ b/src/core/llm/gemini.ts
@@ -28,6 +28,12 @@ import {
 } from './exception'
 
 /**
+ * TODO: Consider future migration from '@google/generative-ai' to '@google/genai' (https://github.com/googleapis/js-genai)
+ * - Current '@google/generative-ai' library will not support newest models and features
+ * - Not migrating yet as '@google/genai' is still in preview status
+ */
+
+/**
  * Note on OpenAI Compatibility API:
  * Gemini provides an OpenAI-compatible endpoint (https://ai.google.dev/gemini-api/docs/openai)
  * which allows using the OpenAI SDK with Gemini models. However, there are currently CORS issues

--- a/src/settings/schema/migrations/6_to_7.test.ts
+++ b/src/settings/schema/migrations/6_to_7.test.ts
@@ -1,4 +1,4 @@
-import { DEFAULT_CHAT_MODELS_V6, migrateFrom6To7 } from './6_to_7'
+import { DEFAULT_CHAT_MODELS_V7, migrateFrom6To7 } from './6_to_7'
 
 describe('Migration from v6 to v7', () => {
   it('should use default models if chatModels is not present', () => {
@@ -7,7 +7,7 @@ describe('Migration from v6 to v7', () => {
     }
     const result = migrateFrom6To7(oldSettings)
     expect(result.version).toBe(7)
-    expect(result.chatModels).toEqual(DEFAULT_CHAT_MODELS_V6)
+    expect(result.chatModels).toEqual(DEFAULT_CHAT_MODELS_V7)
   })
 
   it('should add default models and preserve custom models', () => {
@@ -31,7 +31,7 @@ describe('Migration from v6 to v7', () => {
     }
     const result = migrateFrom6To7(oldSettings)
     expect(result.chatModels).toEqual([
-      ...DEFAULT_CHAT_MODELS_V6,
+      ...DEFAULT_CHAT_MODELS_V7,
       {
         providerType: 'openai-compatible',
         providerId: 'perplexity',
@@ -86,7 +86,7 @@ describe('Migration from v6 to v7', () => {
 
     const result = migrateFrom6To7(oldSettings)
     expect(result.chatModels).toEqual([
-      ...DEFAULT_CHAT_MODELS_V6.map((model) => {
+      ...DEFAULT_CHAT_MODELS_V7.map((model) => {
         if (model.id === 'gpt-4o' || model.id === 'deepseek-chat') {
           return {
             ...model,

--- a/src/settings/schema/migrations/6_to_7.test.ts
+++ b/src/settings/schema/migrations/6_to_7.test.ts
@@ -1,0 +1,106 @@
+import { DEFAULT_CHAT_MODELS_V6, migrateFrom6To7 } from './6_to_7'
+
+describe('Migration from v6 to v7', () => {
+  it('should use default models if chatModels is not present', () => {
+    const oldSettings = {
+      version: 6,
+    }
+    const result = migrateFrom6To7(oldSettings)
+    expect(result.version).toBe(7)
+    expect(result.chatModels).toEqual(DEFAULT_CHAT_MODELS_V6)
+  })
+
+  it('should add default models and preserve custom models', () => {
+    const oldSettings = {
+      version: 6,
+      chatModels: [
+        {
+          providerType: 'anthropic',
+          providerId: 'anthropic',
+          id: 'claude-3.7-sonnet',
+          model: 'claude-3-7-sonnet-latest',
+        },
+        {
+          providerType: 'openai-compatible',
+          providerId: 'perplexity',
+          id: 'perplexity-sonar',
+          model: 'sonar',
+          enable: false,
+        },
+      ],
+    }
+    const result = migrateFrom6To7(oldSettings)
+    expect(result.chatModels).toEqual([
+      ...DEFAULT_CHAT_MODELS_V6,
+      {
+        providerType: 'openai-compatible',
+        providerId: 'perplexity',
+        id: 'perplexity-sonar',
+        model: 'sonar',
+        enable: false,
+      },
+    ])
+  })
+
+  it('should replace models that are in the new default models', () => {
+    const oldSettings = {
+      version: 6,
+      chatModels: [
+        {
+          providerType: 'anthropic',
+          providerId: 'anthropic',
+          id: 'claude-3.7-sonnet',
+          model: 'claude-3-7-sonnet-latest',
+        },
+        {
+          providerType: 'openai',
+          providerId: 'openai',
+          id: 'gpt-4o',
+          model: 'gpt-4o',
+          enable: false,
+        },
+        {
+          providerType: 'deepseek',
+          providerId: 'deepseek',
+          id: 'deepseek-chat',
+          model: 'deepseek-chat',
+          enable: false,
+        },
+        {
+          providerType: 'anthropic',
+          providerId: 'anthropic',
+          id: 'claude-3.7-sonnet-thinking',
+          model: 'claude-3-7-sonnet-latest',
+          thinking: {
+            budget_tokens: 8192,
+          },
+        },
+        {
+          providerType: 'gemini',
+          providerId: 'gemini',
+          id: 'gemini-exp-1206',
+          model: 'gemini-exp-1206',
+        },
+      ],
+    }
+
+    const result = migrateFrom6To7(oldSettings)
+    expect(result.chatModels).toEqual([
+      ...DEFAULT_CHAT_MODELS_V6.map((model) => {
+        if (model.id === 'gpt-4o' || model.id === 'deepseek-chat') {
+          return {
+            ...model,
+            enable: false,
+          }
+        }
+        return model
+      }),
+      {
+        providerType: 'gemini',
+        providerId: 'gemini',
+        id: 'gemini-exp-1206',
+        model: 'gemini-exp-1206',
+      },
+    ])
+  })
+})

--- a/src/settings/schema/migrations/6_to_7.ts
+++ b/src/settings/schema/migrations/6_to_7.ts
@@ -7,7 +7,7 @@ import { SettingMigration } from '../setting.types'
  * - Sort default models by provider type
  */
 
-export const DEFAULT_CHAT_MODELS_V6: {
+export const DEFAULT_CHAT_MODELS_V7: {
   id: string
   providerType: string
   providerId: string
@@ -134,11 +134,11 @@ export const migrateFrom6To7: SettingMigration['migrate'] = (data) => {
   if (!('chatModels' in newData && Array.isArray(newData.chatModels))) {
     return {
       ...newData,
-      chatModels: DEFAULT_CHAT_MODELS_V6,
+      chatModels: DEFAULT_CHAT_MODELS_V7,
     }
   }
 
-  const defaultChatModels = DEFAULT_CHAT_MODELS_V6.map((model) => {
+  const defaultChatModels = DEFAULT_CHAT_MODELS_V7.map((model) => {
     const existingModel = (newData.chatModels as unknown[]).find(
       (m: unknown) => {
         return (m as { id: string }).id === model.id

--- a/src/settings/schema/migrations/6_to_7.ts
+++ b/src/settings/schema/migrations/6_to_7.ts
@@ -1,0 +1,165 @@
+import { PROVIDER_TYPES_INFO } from '../../../constants'
+import { SettingMigration } from '../setting.types'
+
+/**
+ * Migration from version 6 to version 7
+ * - Add gemini models
+ * - Sort default models by provider type
+ */
+
+export const DEFAULT_CHAT_MODELS_V6: {
+  id: string
+  providerType: string
+  providerId: string
+  model: string
+  reasoning_effort?: string
+  thinking?: {
+    budget_tokens: number
+  }
+  enable?: boolean
+}[] = [
+  {
+    providerType: 'anthropic',
+    providerId: PROVIDER_TYPES_INFO.anthropic.defaultProviderId,
+    id: 'claude-3.7-sonnet',
+    model: 'claude-3-7-sonnet-latest',
+  },
+  {
+    providerType: 'anthropic',
+    providerId: PROVIDER_TYPES_INFO.anthropic.defaultProviderId,
+    id: 'claude-3.7-sonnet-thinking',
+    model: 'claude-3-7-sonnet-latest',
+    thinking: {
+      budget_tokens: 8192,
+    },
+  },
+  {
+    providerType: 'anthropic',
+    providerId: PROVIDER_TYPES_INFO.anthropic.defaultProviderId,
+    id: 'claude-3.5-sonnet',
+    model: 'claude-3-5-sonnet-latest',
+  },
+  {
+    providerType: 'anthropic',
+    providerId: PROVIDER_TYPES_INFO.anthropic.defaultProviderId,
+    id: 'claude-3.5-haiku',
+    model: 'claude-3-5-haiku-latest',
+  },
+  {
+    providerType: 'openai',
+    providerId: PROVIDER_TYPES_INFO.openai.defaultProviderId,
+    id: 'gpt-4o',
+    model: 'gpt-4o',
+  },
+  {
+    providerType: 'openai',
+    providerId: PROVIDER_TYPES_INFO.openai.defaultProviderId,
+    id: 'gpt-4o-mini',
+    model: 'gpt-4o-mini',
+  },
+  {
+    providerType: 'openai',
+    providerId: PROVIDER_TYPES_INFO.openai.defaultProviderId,
+    id: 'o3-mini',
+    model: 'o3-mini',
+    reasoning_effort: 'medium',
+  },
+  {
+    providerType: 'openai',
+    providerId: PROVIDER_TYPES_INFO.openai.defaultProviderId,
+    id: 'o1',
+    model: 'o1',
+    reasoning_effort: 'medium',
+  },
+  {
+    providerType: 'gemini',
+    providerId: PROVIDER_TYPES_INFO.gemini.defaultProviderId,
+    id: 'gemini-2.5-pro',
+    model: 'gemini-2.5-pro-preview-03-25',
+  },
+  {
+    providerType: 'gemini',
+    providerId: PROVIDER_TYPES_INFO.gemini.defaultProviderId,
+    id: 'gemini-2.0-flash',
+    model: 'gemini-2.0-flash',
+  },
+  {
+    providerType: 'gemini',
+    providerId: PROVIDER_TYPES_INFO.gemini.defaultProviderId,
+    id: 'gemini-2.0-flash-thinking',
+    model: 'gemini-2.0-flash-thinking-exp',
+  },
+  {
+    providerType: 'gemini',
+    providerId: PROVIDER_TYPES_INFO.gemini.defaultProviderId,
+    id: 'gemini-2.0-flash-lite',
+    model: 'gemini-2.0-flash-lite',
+  },
+  {
+    providerType: 'gemini',
+    providerId: PROVIDER_TYPES_INFO.gemini.defaultProviderId,
+    id: 'gemini-1.5-pro',
+    model: 'gemini-1.5-pro',
+  },
+  {
+    providerType: 'gemini',
+    providerId: PROVIDER_TYPES_INFO.gemini.defaultProviderId,
+    id: 'gemini-1.5-flash',
+    model: 'gemini-1.5-flash',
+  },
+  {
+    providerType: 'deepseek',
+    providerId: PROVIDER_TYPES_INFO.deepseek.defaultProviderId,
+    id: 'deepseek-chat',
+    model: 'deepseek-chat',
+  },
+  {
+    providerType: 'deepseek',
+    providerId: PROVIDER_TYPES_INFO.deepseek.defaultProviderId,
+    id: 'deepseek-reasoner',
+    model: 'deepseek-reasoner',
+  },
+  {
+    providerType: 'morph',
+    providerId: PROVIDER_TYPES_INFO.morph.defaultProviderId,
+    id: 'morph-v0',
+    model: 'morph-v0',
+  },
+]
+
+export const migrateFrom6To7: SettingMigration['migrate'] = (data) => {
+  const newData = { ...data }
+  newData.version = 7
+
+  if (!('chatModels' in newData && Array.isArray(newData.chatModels))) {
+    return {
+      ...newData,
+      chatModels: DEFAULT_CHAT_MODELS_V6,
+    }
+  }
+
+  const defaultChatModels = DEFAULT_CHAT_MODELS_V6.map((model) => {
+    const existingModel = (newData.chatModels as unknown[]).find(
+      (m: unknown) => {
+        return (m as { id: string }).id === model.id
+      },
+    )
+    if (existingModel) {
+      return Object.assign(existingModel, model)
+    }
+    return model
+  })
+
+  const customChatModels = (newData.chatModels as unknown[]).filter(
+    (m: unknown) => {
+      return !defaultChatModels.some(
+        (dm: unknown) => (dm as { id: string }).id === (m as { id: string }).id,
+      )
+    },
+  )
+
+  return {
+    ...newData,
+    chatModels: [...defaultChatModels, ...customChatModels],
+  }
+}

--- a/src/settings/schema/migrations/index.ts
+++ b/src/settings/schema/migrations/index.ts
@@ -6,8 +6,9 @@ import { migrateFrom2To3 } from './2_to_3'
 import { migrateFrom3To4 } from './3_to_4'
 import { migrateFrom4To5 } from './4_to_5'
 import { migrateFrom5To6 } from './5_to_6'
+import { migrateFrom6To7 } from './6_to_7'
 
-export const SETTINGS_SCHEMA_VERSION = 6
+export const SETTINGS_SCHEMA_VERSION = 7
 
 export const SETTING_MIGRATIONS: SettingMigration[] = [
   {
@@ -39,5 +40,10 @@ export const SETTING_MIGRATIONS: SettingMigration[] = [
     fromVersion: 5,
     toVersion: 6,
     migrate: migrateFrom5To6,
+  },
+  {
+    fromVersion: 6,
+    toVersion: 7,
+    migrate: migrateFrom6To7,
   },
 ]

--- a/src/settings/schema/settings.ts
+++ b/src/settings/schema/settings.ts
@@ -8,7 +8,7 @@ function migrateSettings(
   data: Record<string, unknown>,
 ): Record<string, unknown> {
   let currentData = { ...data }
-  const currentVersion = (currentData.version as number) ?? 0
+  let currentVersion = (currentData.version as number) ?? 0
 
   for (const migration of SETTING_MIGRATIONS) {
     if (
@@ -20,6 +20,7 @@ function migrateSettings(
         `Migrating settings from ${migration.fromVersion} to ${migration.toVersion}`,
       )
       currentData = migration.migrate(currentData)
+      currentVersion = migration.toVersion
     }
   }
 

--- a/src/utils/chat/diff.ts
+++ b/src/utils/chat/diff.ts
@@ -22,7 +22,7 @@ export function createDiffBlocks(
   const blocks: DiffBlock[] = []
 
   const advOptions: ILinesDiffComputerOptions = {
-    ignoreTrimWhitespace: true,
+    ignoreTrimWhitespace: false,
     computeMoves: true,
     maxComputationTimeMs: 0,
   }


### PR DESCRIPTION
## Description
- Upgraded @google/generative-ai from v0.21.0 to v0.24.0
- Updated Gemini model list:
  - Added gemini-2.5-pro-preview-03-25 as the new default model
  - Changed gemini-2.0-flash-exp to gemini-2.0-flash (stable release)
  - Added gemini-2.0-flash-lite model
  - Removed gemini-exp-1206
  - Kept gemini-1.5-pro but lowered priority in model list
- Added migration from settings schema v6 to v7
- Added TODO note about future migration to @google/genai package
- Fixed diff display by disabling whitespace trimming

## Checklist before requesting a review
- [x] I have reviewed the [guidelines for contributing](../CONTRIBUTING.md) to this repository.
- [x] I have performed a self-review of my code
- [x] I have performed a code linting check and type check (by running `npm run lint:check` and `npm run type:check`)
- [x] I have run the test suite (by running `npm run test`)
- [x] I have tested the functionality manually


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Enhanced chat model options now offer updated and additional configurations for a refined experience.
  - Seamless settings migration improves configuration management and ensures smooth transitions.
  - Improved difference view now factors in whitespace, providing more precise comparisons.
  - New test cases validate the migration functionality from version 6 to version 7 of the settings schema.
  
- **Bug Fixes**
  - Updates to chat model identifiers and names ensure compatibility with the latest features.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->