### PR TITLE
feat: Add markdown preview mode to assistant response

### DIFF
--- a/src/ChatView.tsx
+++ b/src/ChatView.tsx
@@ -6,6 +6,7 @@ import { Root, createRoot } from 'react-dom/client'
 import Chat, { ChatProps, ChatRef } from './components/chat-view/Chat'
 import { CHAT_VIEW_TYPE } from './constants'
 import { AppProvider } from './contexts/app-context'
+import { ChatViewProvider } from './contexts/chat-view-context'
 import { DarkModeProvider } from './contexts/dark-mode-context'
 import { DatabaseProvider } from './contexts/database-context'
 import { DialogContainerProvider } from './contexts/dialog-container-context'
@@ -67,33 +68,35 @@ export class ChatView extends ItemView {
     })
 
     this.root.render(
-      <AppProvider app={this.app}>
-        <SettingsProvider
-          settings={this.plugin.settings}
-          setSettings={(newSettings) => this.plugin.setSettings(newSettings)}
-          addSettingsChangeListener={(listener) =>
-            this.plugin.addSettingsChangeListener(listener)
-          }
-        >
-          <DarkModeProvider>
-            <DatabaseProvider
-              getDatabaseManager={() => this.plugin.getDbManager()}
-            >
-              <RAGProvider getRAGEngine={() => this.plugin.getRAGEngine()}>
-                <QueryClientProvider client={queryClient}>
-                  <React.StrictMode>
-                    <DialogContainerProvider
-                      container={this.containerEl.children[1] as HTMLElement}
-                    >
-                      <Chat ref={this.chatRef} {...this.initialChatProps} />
-                    </DialogContainerProvider>
-                  </React.StrictMode>
-                </QueryClientProvider>
-              </RAGProvider>
-            </DatabaseProvider>
-          </DarkModeProvider>
-        </SettingsProvider>
-      </AppProvider>,
+      <ChatViewProvider chatView={this}>
+        <AppProvider app={this.app}>
+          <SettingsProvider
+            settings={this.plugin.settings}
+            setSettings={(newSettings) => this.plugin.setSettings(newSettings)}
+            addSettingsChangeListener={(listener) =>
+              this.plugin.addSettingsChangeListener(listener)
+            }
+          >
+            <DarkModeProvider>
+              <DatabaseProvider
+                getDatabaseManager={() => this.plugin.getDbManager()}
+              >
+                <RAGProvider getRAGEngine={() => this.plugin.getRAGEngine()}>
+                  <QueryClientProvider client={queryClient}>
+                    <React.StrictMode>
+                      <DialogContainerProvider
+                        container={this.containerEl.children[1] as HTMLElement}
+                      >
+                        <Chat ref={this.chatRef} {...this.initialChatProps} />
+                      </DialogContainerProvider>
+                    </React.StrictMode>
+                  </QueryClientProvider>
+                </RAGProvider>
+              </DatabaseProvider>
+            </DarkModeProvider>
+          </SettingsProvider>
+        </AppProvider>
+      </ChatViewProvider>,
     )
   }
 

--- a/src/components/chat-view/MarkdownCodeComponent.tsx
+++ b/src/components/chat-view/MarkdownCodeComponent.tsx
@@ -1,8 +1,11 @@
-import { Check, CopyIcon, Loader2 } from 'lucide-react'
+import { Check, CopyIcon, Eye, Loader2, Play } from 'lucide-react'
 import { PropsWithChildren, useMemo, useState } from 'react'
 
+import { useApp } from '../../contexts/app-context'
 import { useDarkModeContext } from '../../contexts/dark-mode-context'
+import { openMarkdownFile } from '../../utils/obsidian'
 
+import ObsidianMarkdown from './ObsidianMarkdown'
 import { MemoizedSyntaxHighlighterWrapper } from './SyntaxHighlighterWrapper'
 
 export default function MarkdownCodeComponent({
@@ -17,8 +20,11 @@ export default function MarkdownCodeComponent({
   language?: string
   filename?: string
 }>) {
-  const [copied, setCopied] = useState(false)
+  const app = useApp()
   const { isDarkMode } = useDarkModeContext()
+
+  const [isPreviewMode, setIsPreviewMode] = useState(true)
+  const [copied, setCopied] = useState(false)
 
   const wrapLines = useMemo(() => {
     return !language || ['markdown'].includes(language)
@@ -34,13 +40,32 @@ export default function MarkdownCodeComponent({
     }
   }
 
+  const handleOpenFile = () => {
+    if (filename) {
+      openMarkdownFile(app, filename)
+    }
+  }
+
   return (
     <div className={`smtcmp-code-block ${filename ? 'has-filename' : ''}`}>
       <div className={'smtcmp-code-block-header'}>
         {filename && (
-          <div className={'smtcmp-code-block-header-filename'}>{filename}</div>
+          <div
+            className={'smtcmp-code-block-header-filename'}
+            onClick={handleOpenFile}
+          >
+            {filename}
+          </div>
         )}
         <div className={'smtcmp-code-block-header-button'}>
+          <button
+            onClick={() => {
+              setIsPreviewMode(!isPreviewMode)
+            }}
+          >
+            <Eye size={12} />
+            {isPreviewMode ? 'View Raw Text' : 'View Formatted'}
+          </button>
           <button
             onClick={() => {
               handleCopy()
@@ -48,11 +73,13 @@ export default function MarkdownCodeComponent({
           >
             {copied ? (
               <>
-                <Check size={10} /> Copied
+                <Check size={10} />
+                <span>Copied</span>
               </>
             ) : (
               <>
-                <CopyIcon size={10} /> Copy
+                <CopyIcon size={10} />
+                <span>Copy</span>
               </>
             )}
           </button>
@@ -64,22 +91,32 @@ export default function MarkdownCodeComponent({
           >
             {isApplying ? (
               <>
-                <Loader2 className="spinner" size={14} /> Applying...
+                <Loader2 className="spinner" size={14} />
+                <span>Applying...</span>
               </>
             ) : (
-              'Apply'
+              <>
+                <Play size={10} />
+                <span>Apply</span>
+              </>
             )}
           </button>
         </div>
       </div>
-      <MemoizedSyntaxHighlighterWrapper
-        isDarkMode={isDarkMode}
-        language={language}
-        hasFilename={!!filename}
-        wrapLines={wrapLines}
-      >
-        {String(children)}
-      </MemoizedSyntaxHighlighterWrapper>
+      {isPreviewMode ? (
+        <div className="smtcmp-code-block-obsidian-markdown">
+          <ObsidianMarkdown content={String(children)} />
+        </div>
+      ) : (
+        <MemoizedSyntaxHighlighterWrapper
+          isDarkMode={isDarkMode}
+          language={language}
+          hasFilename={!!filename}
+          wrapLines={wrapLines}
+        >
+          {String(children)}
+        </MemoizedSyntaxHighlighterWrapper>
+      )}
     </div>
   )
 }

--- a/src/components/chat-view/MarkdownReferenceBlock.tsx
+++ b/src/components/chat-view/MarkdownReferenceBlock.tsx
@@ -1,9 +1,11 @@
+import { Eye } from 'lucide-react'
 import { PropsWithChildren, useEffect, useMemo, useState } from 'react'
 
 import { useApp } from '../../contexts/app-context'
 import { useDarkModeContext } from '../../contexts/dark-mode-context'
 import { openMarkdownFile, readTFileContent } from '../../utils/obsidian'
 
+import ObsidianMarkdown from './ObsidianMarkdown'
 import { MemoizedSyntaxHighlighterWrapper } from './SyntaxHighlighterWrapper'
 
 export default function MarkdownReferenceBlock({
@@ -19,6 +21,8 @@ export default function MarkdownReferenceBlock({
 }>) {
   const app = useApp()
   const { isDarkMode } = useDarkModeContext()
+
+  const [isPreviewMode, setIsPreviewMode] = useState(true)
   const [blockContent, setBlockContent] = useState<string | null>(null)
 
   const wrapLines = useMemo(() => {
@@ -43,32 +47,47 @@ export default function MarkdownReferenceBlock({
     fetchBlockContent()
   }, [filename, startLine, endLine, app.vault])
 
-  const handleClick = () => {
+  const handleOpenFile = () => {
     openMarkdownFile(app, filename, startLine)
   }
 
-  // TODO: Update styles
   return (
     blockContent && (
-      <div
-        className={`smtcmp-code-block ${filename ? 'has-filename' : ''}`}
-        onClick={handleClick}
-      >
+      <div className={`smtcmp-code-block ${filename ? 'has-filename' : ''}`}>
         <div className={'smtcmp-code-block-header'}>
           {filename && (
-            <div className={'smtcmp-code-block-header-filename'}>
+            <div
+              className={'smtcmp-code-block-header-filename'}
+              onClick={handleOpenFile}
+            >
               {filename}
             </div>
           )}
+          <div className={'smtcmp-code-block-header-button'}>
+            <button
+              onClick={() => {
+                setIsPreviewMode(!isPreviewMode)
+              }}
+            >
+              <Eye size={12} />
+              {isPreviewMode ? 'View Raw Text' : 'View Formatted'}
+            </button>
+          </div>
         </div>
-        <MemoizedSyntaxHighlighterWrapper
-          isDarkMode={isDarkMode}
-          language={language}
-          hasFilename={!!filename}
-          wrapLines={wrapLines}
-        >
-          {blockContent}
-        </MemoizedSyntaxHighlighterWrapper>
+        {isPreviewMode ? (
+          <div className="smtcmp-code-block-obsidian-markdown">
+            <ObsidianMarkdown content={blockContent} />
+          </div>
+        ) : (
+          <MemoizedSyntaxHighlighterWrapper
+            isDarkMode={isDarkMode}
+            language={language}
+            hasFilename={!!filename}
+            wrapLines={wrapLines}
+          >
+            {blockContent}
+          </MemoizedSyntaxHighlighterWrapper>
+        )}
       </div>
     )
   )

--- a/src/components/chat-view/ObsidianMarkdown.tsx
+++ b/src/components/chat-view/ObsidianMarkdown.tsx
@@ -35,8 +35,6 @@ export default function ObsidianMarkdown({ content }: ObsidianMarkdownProps) {
         containerRef.current,
         app.workspace.getActiveFile()?.path ?? '',
       )
-
-      setupFrontmatterDisplay(containerRef.current)
     }
   }, [app, content, chatView])
 
@@ -85,25 +83,4 @@ function setupMarkdownLinks(
       })
     }
   })
-}
-
-/**
- * Shows the frontmatter section rendered by MarkdownRenderer.render(),
- * which is hidden by default.
- */
-function setupFrontmatterDisplay(containerEl: HTMLElement) {
-  const frontmatterEl = containerEl.querySelector('.frontmatter')
-  if (!frontmatterEl || !(frontmatterEl instanceof HTMLElement)) {
-    return
-  }
-  // Show frontmatter section that is hidden by default
-  frontmatterEl.style.display = 'block'
-  frontmatterEl.style.backgroundColor = 'transparent'
-  frontmatterEl.classList.add('cm-hmd-frontmatter')
-
-  // Hide the copy code button
-  const copyCodeButton = frontmatterEl.querySelector('.copy-code-button')
-  if (copyCodeButton && copyCodeButton instanceof HTMLElement) {
-    copyCodeButton.style.display = 'none'
-  }
 }

--- a/src/components/chat-view/ObsidianMarkdown.tsx
+++ b/src/components/chat-view/ObsidianMarkdown.tsx
@@ -1,0 +1,109 @@
+import { App, Keymap, MarkdownRenderer } from 'obsidian'
+import { useCallback, useEffect, useRef } from 'react'
+
+import { useApp } from '../../contexts/app-context'
+import { useChatView } from '../../contexts/chat-view-context'
+
+type ObsidianMarkdownProps = {
+  content: string
+}
+
+/**
+ * Renders Obsidian Markdown content using the Obsidian MarkdownRenderer.
+ *
+ * @param content - The Obsidian Markdown content to render.
+ * @returns A React component that renders the Obsidian Markdown content.
+ */
+export default function ObsidianMarkdown({ content }: ObsidianMarkdownProps) {
+  const app = useApp()
+  const chatView = useChatView()
+  const containerRef = useRef<HTMLDivElement>(null)
+
+  const renderMarkdown = useCallback(async () => {
+    if (containerRef.current) {
+      containerRef.current.innerHTML = ''
+      await MarkdownRenderer.render(
+        app,
+        content,
+        containerRef.current,
+        app.workspace.getActiveFile()?.path ?? '',
+        chatView,
+      )
+
+      setupMarkdownLinks(
+        app,
+        containerRef.current,
+        app.workspace.getActiveFile()?.path ?? '',
+      )
+
+      setupFrontmatterDisplay(containerRef.current)
+    }
+  }, [app, content, chatView])
+
+  useEffect(() => {
+    renderMarkdown()
+  }, [renderMarkdown])
+
+  return <div ref={containerRef} />
+}
+
+/**
+ * Adds click and hover handlers to internal links rendered by MarkdownRenderer.render().
+ * Required because rendered links are not interactive by default.
+ *
+ * @see https://forum.obsidian.md/t/internal-links-dont-work-in-custom-view/90169/3
+ */
+function setupMarkdownLinks(
+  app: App,
+  containerEl: HTMLElement,
+  sourcePath: string,
+  showLinkHover?: boolean,
+) {
+  containerEl.querySelectorAll('a.internal-link').forEach((el) => {
+    el.addEventListener('click', (evt: MouseEvent) => {
+      evt.preventDefault()
+      const linktext = el.getAttribute('href')
+      if (linktext) {
+        app.workspace.openLinkText(linktext, sourcePath, Keymap.isModEvent(evt))
+      }
+    })
+
+    if (showLinkHover) {
+      el.addEventListener('mouseover', (event: MouseEvent) => {
+        event.preventDefault()
+        const linktext = el.getAttribute('href')
+        if (linktext) {
+          app.workspace.trigger('hover-link', {
+            event,
+            source: 'preview',
+            hoverParent: { hoverPopover: null },
+            targetEl: event.currentTarget,
+            linktext: linktext,
+            sourcePath: sourcePath,
+          })
+        }
+      })
+    }
+  })
+}
+
+/**
+ * Shows the frontmatter section rendered by MarkdownRenderer.render(),
+ * which is hidden by default.
+ */
+function setupFrontmatterDisplay(containerEl: HTMLElement) {
+  const frontmatterEl = containerEl.querySelector('.frontmatter')
+  if (!frontmatterEl || !(frontmatterEl instanceof HTMLElement)) {
+    return
+  }
+  // Show frontmatter section that is hidden by default
+  frontmatterEl.style.display = 'block'
+  frontmatterEl.style.backgroundColor = 'transparent'
+  frontmatterEl.classList.add('cm-hmd-frontmatter')
+
+  // Hide the copy code button
+  const copyCodeButton = frontmatterEl.querySelector('.copy-code-button')
+  if (copyCodeButton && copyCodeButton instanceof HTMLElement) {
+    copyCodeButton.style.display = 'none'
+  }
+}

--- a/src/contexts/chat-view-context.tsx
+++ b/src/contexts/chat-view-context.tsx
@@ -1,0 +1,27 @@
+import React from 'react'
+
+import { ChatView } from '../ChatView'
+
+const ChatViewContext = React.createContext<ChatView | undefined>(undefined)
+
+export const ChatViewProvider = ({
+  children,
+  chatView,
+}: {
+  children: React.ReactNode
+  chatView: ChatView
+}) => {
+  return (
+    <ChatViewContext.Provider value={chatView}>
+      {children}
+    </ChatViewContext.Provider>
+  )
+}
+
+export const useChatView = () => {
+  const chatView = React.useContext(ChatViewContext)
+  if (!chatView) {
+    throw new Error('useChatView must be used within a ChatViewProvider')
+  }
+  return chatView
+}

--- a/src/utils/chat/parse-tag-content.test.ts
+++ b/src/utils/chat/parse-tag-content.test.ts
@@ -23,11 +23,10 @@ print("Hello, world!")
 Some text after`
 
     const expected: ParsedTagContent[] = [
-      { type: 'string', content: 'Some text before\n' },
+      { type: 'string', content: 'Some text before' },
       {
         type: 'smtcmp_block',
-        content: `
-# Example Markdown
+        content: `# Example Markdown
 
 This is a sample markdown content for testing purposes.
 
@@ -41,12 +40,11 @@ This is a sample markdown content for testing purposes.
 ### Code Block
 \`\`\`python
 print("Hello, world!")
-\`\`\`
-`,
+\`\`\``,
         language: 'markdown',
         filename: 'example.md',
       },
-      { type: 'string', content: '\nSome text after' },
+      { type: 'string', content: 'Some text after' },
     ]
 
     const result = parseTagContents(input)
@@ -59,14 +57,14 @@ print("Hello, world!")
     `
 
     const expected: ParsedTagContent[] = [
-      { type: 'string', content: '\n      ' },
+      { type: 'string', content: '      ' },
       {
         type: 'smtcmp_block',
         content: '',
         language: 'python',
         filename: undefined,
       },
-      { type: 'string', content: '\n    ' },
+      { type: 'string', content: '    ' },
     ]
 
     const result = parseTagContents(input)
@@ -101,32 +99,28 @@ print("Hello, world!")
 End`
 
     const expected: ParsedTagContent[] = [
-      { type: 'string', content: 'Start\n' },
+      { type: 'string', content: 'Start' },
       {
         type: 'smtcmp_block',
-        content: `
-def greet(name):
-    print(f"Hello, {name}!")
-`,
+        content: `def greet(name):
+    print(f"Hello, {name}!")`,
         language: 'python',
         filename: 'script.py',
       },
-      { type: 'string', content: '\nMiddle\n' },
+      { type: 'string', content: 'Middle' },
       {
         type: 'smtcmp_block',
-        content: `
-# Using tildes for code blocks
+        content: `# Using tildes for code blocks
 
 Did you know that you can use tildes for code blocks?
 
 ~~~python
 print("Hello, world!")
-~~~
-`,
+~~~`,
         language: 'markdown',
         filename: 'example.md',
       },
-      { type: 'string', content: '\nEnd' },
+      { type: 'string', content: 'End' },
     ]
 
     const result = parseTagContents(input)
@@ -140,11 +134,10 @@ print("Hello, world!")
 
 Some text after without closing tag`
     const expected: ParsedTagContent[] = [
-      { type: 'string', content: 'Start\n' },
+      { type: 'string', content: 'Start' },
       {
         type: 'smtcmp_block',
-        content: `
-# Unfinished smtcmp_block
+        content: `# Unfinished smtcmp_block
 
 Some text after without closing tag`,
         language: 'markdown',
@@ -179,9 +172,9 @@ describe('parseThink', () => {
 <think>Thinking...</think>
 End`
     const expected: ParsedTagContent[] = [
-      { type: 'string', content: 'Start\n' },
+      { type: 'string', content: 'Start' },
       { type: 'think', content: 'Thinking...' },
-      { type: 'string', content: '\nEnd' },
+      { type: 'string', content: 'End' },
     ]
 
     const result = parseTagContents(input)
@@ -193,7 +186,7 @@ End`
 <think>Thinking...
 Some text after without closing tag`
     const expected: ParsedTagContent[] = [
-      { type: 'string', content: 'Start\n' },
+      { type: 'string', content: 'Start' },
       {
         type: 'think',
         content: 'Thinking...\nSome text after without closing tag',
@@ -211,11 +204,11 @@ Some text after
 <think>Second thought</think>
 End`
     const expected: ParsedTagContent[] = [
-      { type: 'string', content: 'Start\n' },
+      { type: 'string', content: 'Start' },
       { type: 'think', content: 'First thought' },
-      { type: 'string', content: '\nSome text after\n' },
+      { type: 'string', content: 'Some text after' },
       { type: 'think', content: 'Second thought' },
-      { type: 'string', content: '\nEnd' },
+      { type: 'string', content: 'End' },
     ]
 
     const result = parseTagContents(input)
@@ -243,13 +236,12 @@ This is a sample markdown content for testing purposes.
 End`
 
     const expected: ParsedTagContent[] = [
-      { type: 'string', content: 'Start\n' },
+      { type: 'string', content: 'Start' },
       { type: 'think', content: 'Thinking...' },
-      { type: 'string', content: '\n\n' },
+      { type: 'string', content: '' },
       {
         type: 'smtcmp_block',
-        content: `
-# Example Markdown
+        content: `# Example Markdown
 
 This is a sample markdown content for testing purposes.
 
@@ -258,14 +250,13 @@ This is a sample markdown content for testing purposes.
 - Lists
 - **Bold text**
 - *Italic text*
-- [Links](https://example.com)
-`,
+- [Links](https://example.com)`,
         language: 'markdown',
         filename: 'example.md',
         startLine: undefined,
         endLine: undefined,
       },
-      { type: 'string', content: '\nEnd' },
+      { type: 'string', content: 'End' },
     ]
 
     const result = parseTagContents(input)
@@ -281,11 +272,11 @@ This is a sample markdown content for testing purposes.
 This is a sample markdown content for testing purposes.
 
 ## Features
-</smtcmp_block> 
+</smtcmp_block>
 </think>
 End`
     const expected: ParsedTagContent[] = [
-      { type: 'string', content: 'Start\n' },
+      { type: 'string', content: 'Start' },
       {
         type: 'think',
         content: `Thinking...
@@ -295,10 +286,9 @@ End`
 This is a sample markdown content for testing purposes.
 
 ## Features
-</smtcmp_block> 
-`,
+</smtcmp_block>`,
       },
-      { type: 'string', content: '\nEnd' },
+      { type: 'string', content: 'End' },
     ]
 
     const result = parseTagContents(input)

--- a/src/utils/chat/parse-tag-content.ts
+++ b/src/utils/chat/parse-tag-content.ts
@@ -113,5 +113,23 @@ export function parseTagContents(input: string): ParsedTagContent[] {
       content: input.slice(lastEndOffset),
     })
   }
+
+  /**
+   * Remove a single leading/trailing newline from each block's content.
+   *
+   * Example input:
+   * hello world
+   * <smtcmp_block>
+   * some content
+   * </smtcmp_block>
+   *
+   * Becomes:
+   * { type: 'string', content: 'hello world' }
+   * { type: 'smtcmp_block', content: 'some content' }
+   */
+  parsedResult.forEach((block) => {
+    block.content = block.content.replace(/^\n|\n$/g, '')
+  })
+
   return parsedResult
 }

--- a/styles.css
+++ b/styles.css
@@ -616,6 +616,18 @@ input[type='text'].smtcmp-chat-list-dropdown-item-title-input {
 .smtcmp-code-block-obsidian-markdown {
   padding: 8px;
   font-size: 0.9em;
+
+  /* Show frontmatter which is hidden by default */
+  .frontmatter {
+    display: block !important;
+    background-color: transparent;
+    font-size: var(--font-smaller);
+  }
+
+  /* Hide copy code buttons */
+  .copy-code-button {
+    display: none !important;
+  }
 }
 
 #smtcmp-apply-view {

--- a/styles.css
+++ b/styles.css
@@ -563,6 +563,11 @@ input[type='text'].smtcmp-chat-list-dropdown-item-title-input {
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
+  cursor: pointer;
+
+  &:hover {
+    text-decoration: underline;
+  }
 }
 
 .smtcmp-code-block-header-button {
@@ -606,6 +611,11 @@ input[type='text'].smtcmp-chat-list-dropdown-item-title-input {
 
 .smtcmp-code-block-content {
   margin: 0;
+}
+
+.smtcmp-code-block-obsidian-markdown {
+  padding: 8px;
+  font-size: 0.9em;
 }
 
 #smtcmp-apply-view {


### PR DESCRIPTION
## Description

This PR adds a new "Preview" mode to code blocks in the chat interface, allowing users to view markdown content rendered with Obsidian's native markdown renderer. This provides a more natural reading experience for markdown content within AI responses.

### Key Changes

1. Added an `ObsidianMarkdown` component that renders markdown content using Obsidian's `MarkdownRenderer`
2. Added a toggle button in code blocks to switch between raw text and formatted preview

## Screenshots
![image](https://github.com/user-attachments/assets/d8c4c36d-8586-4e57-aaa9-74a47682ddd6)
![image](https://github.com/user-attachments/assets/adc912b5-107e-450a-b796-505153a8cdd7)

Note: If your changes include UI modifications, please include screenshots to help reviewers visualize the changes.

## Checklist before requesting a review
- [x] I have reviewed the [guidelines for contributing](../CONTRIBUTING.md) to this repository.
- [x] I have performed a self-review of my code
- [x] I have performed a code linting check and type check (by running `npm run lint:check` and `npm run type:check`)
- [x] I have run the test suite (by running `npm run test`)
- [x] I have tested the functionality manually


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Updated chat view foundation to support enhanced markdown interactions.
	- Added a toggle button allowing users to switch between a preview mode and a formatted view of markdown content.
	- Enabled direct file opening by clicking on markdown filename headers.
	- Introduced a dedicated renderer for displaying interactive Obsidian markdown.

- **Bug Fixes**
	- Streamlined markdown content presentation by removing unnecessary newline characters.

- **Style**
	- Refined code block appearance with interactive hover effects and improved layout styling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->