### PR TITLE
style: Replace React Markdown with Obsidian Markdown renderer with scaling support

### DIFF
--- a/src/components/chat-view/AssistantMessageReasoning.tsx
+++ b/src/components/chat-view/AssistantMessageReasoning.tsx
@@ -1,6 +1,7 @@
 import { ChevronDown, ChevronUp } from 'lucide-react'
 import { useEffect, useRef, useState } from 'react'
-import Markdown from 'react-markdown'
+
+import ObsidianMarkdown from './ObsidianMarkdown'
 
 export default function AssistantMessageReasoning({
   reasoning,
@@ -49,7 +50,7 @@ export default function AssistantMessageReasoning({
       </div>
       {isExpanded && (
         <div className="smtcmp-assistant-message-metadata-content">
-          <Markdown className="smtcmp-markdown">{reasoning}</Markdown>
+          <ObsidianMarkdown content={reasoning} scale="xs" />
         </div>
       )}
     </div>

--- a/src/components/chat-view/MarkdownCodeComponent.tsx
+++ b/src/components/chat-view/MarkdownCodeComponent.tsx
@@ -105,7 +105,7 @@ export default function MarkdownCodeComponent({
       </div>
       {isPreviewMode ? (
         <div className="smtcmp-code-block-obsidian-markdown">
-          <ObsidianMarkdown content={String(children)} />
+          <ObsidianMarkdown content={String(children)} scale="sm" />
         </div>
       ) : (
         <MemoizedSyntaxHighlighterWrapper

--- a/src/components/chat-view/MarkdownReferenceBlock.tsx
+++ b/src/components/chat-view/MarkdownReferenceBlock.tsx
@@ -76,7 +76,7 @@ export default function MarkdownReferenceBlock({
         </div>
         {isPreviewMode ? (
           <div className="smtcmp-code-block-obsidian-markdown">
-            <ObsidianMarkdown content={blockContent} />
+            <ObsidianMarkdown content={blockContent} scale="sm" />
           </div>
         ) : (
           <MemoizedSyntaxHighlighterWrapper

--- a/src/components/chat-view/ObsidianMarkdown.tsx
+++ b/src/components/chat-view/ObsidianMarkdown.tsx
@@ -6,15 +6,20 @@ import { useChatView } from '../../contexts/chat-view-context'
 
 type ObsidianMarkdownProps = {
   content: string
+  scale?: 'xs' | 'sm' | 'base'
 }
 
 /**
  * Renders Obsidian Markdown content using the Obsidian MarkdownRenderer.
  *
  * @param content - The Obsidian Markdown content to render.
+ * @param scale - The scale of the markdown content.
  * @returns A React component that renders the Obsidian Markdown content.
  */
-export default function ObsidianMarkdown({ content }: ObsidianMarkdownProps) {
+export default function ObsidianMarkdown({
+  content,
+  scale = 'base',
+}: ObsidianMarkdownProps) {
   const app = useApp()
   const chatView = useChatView()
   const containerRef = useRef<HTMLDivElement>(null)
@@ -42,7 +47,12 @@ export default function ObsidianMarkdown({ content }: ObsidianMarkdownProps) {
     renderMarkdown()
   }, [renderMarkdown])
 
-  return <div ref={containerRef} />
+  return (
+    <div
+      ref={containerRef}
+      className={`markdown-rendered smtcmp-markdown-rendered smtcmp-scale-${scale}`}
+    />
+  )
 }
 
 /**

--- a/src/components/chat-view/ReactMarkdown.tsx
+++ b/src/components/chat-view/ReactMarkdown.tsx
@@ -1,5 +1,4 @@
 import React, { useCallback, useMemo } from 'react'
-import Markdown from 'react-markdown'
 
 import { ChatMessage } from '../../types/chat'
 import {
@@ -10,6 +9,7 @@ import {
 import AssistantMessageReasoning from './AssistantMessageReasoning'
 import MarkdownCodeComponent from './MarkdownCodeComponent'
 import MarkdownReferenceBlock from './MarkdownReferenceBlock'
+import ObsidianMarkdown from './ObsidianMarkdown'
 
 const ReactMarkdown = React.memo(function ReactMarkdown({
   onApply,
@@ -29,9 +29,9 @@ const ReactMarkdown = React.memo(function ReactMarkdown({
     <>
       {blocks.map((block, index) =>
         block.type === 'string' ? (
-          <Markdown key={index} className="smtcmp-markdown">
-            {block.content}
-          </Markdown>
+          <div key={index}>
+            <ObsidianMarkdown content={block.content} scale="sm" />
+          </div>
         ) : block.type === 'think' ? (
           <AssistantMessageReasoning key={index} reasoning={block.content} />
         ) : block.startLine && block.endLine && block.filename ? (

--- a/styles.css
+++ b/styles.css
@@ -577,20 +577,7 @@ input[type='text'].smtcmp-chat-list-dropdown-item-title-input {
 }
 
 .smtcmp-code-block-obsidian-markdown {
-  padding: 8px;
-  font-size: 0.9em;
-
-  /* Show frontmatter which is hidden by default */
-  .frontmatter {
-    display: block !important;
-    background-color: transparent;
-    font-size: var(--font-smaller);
-  }
-
-  /* Hide copy code buttons */
-  .copy-code-button {
-    display: none !important;
-  }
+  padding: var(--size-4-3);
 }
 
 #smtcmp-apply-view {
@@ -1360,4 +1347,78 @@ button.smtcmp-chat-input-model-select {
 .smtcmp-assistant-message-metadata-toggle-icon {
   width: var(--size-4-4);
   height: var(--size-4-4);
+}
+
+/* Overrides default .markdown-rendered class styles from Obsidian */
+.smtcmp-markdown-rendered {
+  &.markdown-rendered {
+    --render-scale: 1;
+    font-size: calc(var(--render-scale) * 1rem);
+    line-height: 1.5;
+
+    &.smtcmp-scale-xs {
+      --render-scale: 0.8;
+    }
+
+    &.smtcmp-scale-sm {
+      --render-scale: 0.85;
+    }
+
+    &.smtcmp-scale-base {
+      --render-scale: 1;
+    }
+
+    /* override default variables */
+    --p-spacing: calc(var(--render-scale) * 1rem);
+    --heading-spacing: calc(var(--p-spacing) * 2.5);
+    --checkbox-size: calc(var(--render-scale) * 1rem);
+    --checkbox-radius: calc(var(--render-scale) * var(--radius-s));
+
+    /* adjust list indent */
+    --list-indent: 1.5em;
+
+    blockquote {
+      padding-inline-start: calc(var(--render-scale) * 1.5rem);
+    }
+
+    pre {
+      padding: calc(var(--render-scale) * 0.75rem)
+        calc(var(--render-scale) * 1rem);
+    }
+
+    hr {
+      margin: calc(var(--render-scale) * 2rem) 0;
+    }
+
+    th,
+    td {
+      font-size: calc(var(--render-scale) * 1rem);
+      padding: calc(var(--render-scale) * 0.25rem)
+        calc(var(--render-scale) * 0.5rem);
+    }
+
+    .callout {
+      padding: calc(var(--render-scale) * 0.75rem)
+        calc(var(--render-scale) * 0.75rem) calc(var(--render-scale) * 0.75rem)
+        calc(var(--render-scale) * 1.5rem);
+    }
+
+    .callout-icon {
+      height: calc(var(--render-scale) * 1rem);
+      width: calc(var(--render-scale) * 1rem);
+    }
+  }
+
+  /* Show frontmatter which is hidden by default */
+  .frontmatter {
+    display: block !important;
+    background-color: transparent;
+    border-top: 1px solid var(--background-modifier-border);
+    border-bottom: 1px solid var(--background-modifier-border);
+  }
+
+  /* Hide copy code buttons */
+  .copy-code-button {
+    display: none !important;
+  }
 }


### PR DESCRIPTION
## Description

- Replace React Markdown with Obsidian Markdown throughout the application
- Add new scale parameter to ObsidianMarkdown component with 'xs', 'sm' and 'base' options
- Add CSS styling for different markdown scales with responsive typography

## Checklist before requesting a review
- [x] I have reviewed the [guidelines for contributing](../CONTRIBUTING.md) to this repository.
- [x] I have performed a self-review of my code
- [x] I have performed a code linting check and type check (by running `npm run lint:check` and `npm run type:check`)
- [x] I have run the test suite (by running `npm run test`)
- [x] I have tested the functionality manually


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced markdown rendering with adjustable scaling for improved display of messages, code blocks, and references.
- **Style**
	- Adopted a flexible, scale-based styling approach that refines typography, spacing, and layout for a cleaner, more consistent presentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->