### PR TITLE
fix: Add encoding_format: 'float' to embedding requests

### DIFF
--- a/src/core/llm/NoStainlessOpenAI.ts
+++ b/src/core/llm/NoStainlessOpenAI.ts
@@ -2,7 +2,7 @@ import OpenAI from 'openai'
 import { FinalRequestOptions } from 'openai/core'
 
 export class NoStainlessOpenAI extends OpenAI {
-  buildRequest<Req>(
+  override buildRequest<Req>(
     options: FinalRequestOptions<Req>,
     { retryCount = 0 }: { retryCount?: number } = {},
   ): { req: RequestInit; url: string; timeout: number } {

--- a/src/core/llm/lmStudioProvider.ts
+++ b/src/core/llm/lmStudioProvider.ts
@@ -59,6 +59,7 @@ export class LmStudioProvider extends BaseLLMProvider<
     const embedding = await this.client.embeddings.create({
       model: model,
       input: text,
+      encoding_format: 'float',
     })
     return embedding.data[0].embedding
   }

--- a/src/core/llm/ollama.ts
+++ b/src/core/llm/ollama.ts
@@ -63,6 +63,7 @@ export class OllamaProvider extends BaseLLMProvider<
     const embedding = await this.client.embeddings.create({
       model: model,
       input: text,
+      encoding_format: 'float',
     })
     return embedding.data[0].embedding
   }

--- a/src/core/llm/openaiCompatibleProvider.ts
+++ b/src/core/llm/openaiCompatibleProvider.ts
@@ -84,6 +84,7 @@ export class OpenAICompatibleProvider extends BaseLLMProvider<
     const embedding = await this.client.embeddings.create({
       model: model,
       input: text,
+      encoding_format: 'float',
     })
     return embedding.data[0].embedding
   }


### PR DESCRIPTION
## Description

Fixes issue #337, #353 where embedding requests failed after OpenAI library update. Adding encoding_format parameter restores original behavior for OpenAI-compatible providers.

## Checklist before requesting a review
- [x] I have reviewed the [guidelines for contributing](../CONTRIBUTING.md) to this repository.
- [x] I have performed a self-review of my code
- [x] I have performed a code linting check and type check (by running `npm run lint:check` and `npm run type:check`)
- [x] I have run the test suite (by running `npm run test`)
- [x] I have tested the functionality manually
