### PR TITLE
Add new OpenAI models

### DIFF
--- a/src/components/settings/sections/models/ChatModelSettings.tsx
+++ b/src/components/settings/sections/models/ChatModelSettings.tsx
@@ -22,11 +22,11 @@ type ModelSettingsRegistry = {
 
 // Registry of available model settings
 const MODEL_SETTINGS_REGISTRY: ModelSettingsRegistry[] = [
-  // OpenAI o1, o1-mini, o3-mini settings
+  // OpenAI o1, o1-mini, o3, o3-mini, o4-mini settings
   {
     check: (model) =>
       model.providerType === 'openai' &&
-      ['o1', 'o1-mini', 'o3-mini'].includes(model.model),
+      ['o1', 'o1-mini', 'o3', 'o3-mini', 'o4-mini'].includes(model.model),
 
     SettingsComponent: (props: SettingsComponentProps) => {
       const { model, plugin, onClose } = props

--- a/src/components/settings/sections/models/ChatModelSettings.tsx
+++ b/src/components/settings/sections/models/ChatModelSettings.tsx
@@ -20,13 +20,21 @@ type ModelSettingsRegistry = {
   SettingsComponent: React.FC<SettingsComponentProps>
 }
 
+const OPEN_AI_REASONING_MODEL_IDS = [
+  'o1',
+  'o1-mini',
+  'o3',
+  'o3-mini',
+  'o4-mini',
+]
+
 // Registry of available model settings
 const MODEL_SETTINGS_REGISTRY: ModelSettingsRegistry[] = [
-  // OpenAI o1, o1-mini, o3, o3-mini, o4-mini settings
+  // OpenAI reasoning model settings
   {
     check: (model) =>
       model.providerType === 'openai' &&
-      ['o1', 'o1-mini', 'o3', 'o3-mini', 'o4-mini'].includes(model.model),
+      OPEN_AI_REASONING_MODEL_IDS.includes(model.model),
 
     SettingsComponent: (props: SettingsComponentProps) => {
       const { model, plugin, onClose } = props

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -12,10 +12,14 @@ type ModelPricing = {
 }
 
 export const OPENAI_PRICES: Record<string, ModelPricing> = {
+  'gpt-4.1': { input: 2.0, output: 8.0 },
+  'gpt-4.1-mini': { input: 0.40, output: 1.6 },
+  'gpt-4.1-nano': { input: 0.10, output: 0.40 },
   'gpt-4o': { input: 2.5, output: 10 },
   'gpt-4o-mini': { input: 0.15, output: 0.6 },
-  'gpt-4.1': { input: 2.0, output: 8.0 },
+  o3: { input: 10, output: 40 },
   o1: { input: 15, output: 60 },
+  'o4-mini': { input: 1.1, output: 4.4 },
   'o3-mini': { input: 1.1, output: 4.4 },
   'o1-mini': { input: 1.1, output: 4.4 },
 }
@@ -263,14 +267,26 @@ export const DEFAULT_CHAT_MODELS: readonly ChatModel[] = [
   {
     providerType: 'openai',
     providerId: PROVIDER_TYPES_INFO.openai.defaultProviderId,
-    id: 'gpt-4o',
-    model: 'gpt-4o',
+    id: 'gpt-4.1',
+    model: 'gpt-4.1',
   },
   {
     providerType: 'openai',
     providerId: PROVIDER_TYPES_INFO.openai.defaultProviderId,
-    id: 'gpt-4.1',
-    model: 'gpt-4.1',
+    id: 'gpt-4.1-mini',
+    model: 'gpt-4.1-mini',
+  },
+  {
+    providerType: 'openai',
+    providerId: PROVIDER_TYPES_INFO.openai.defaultProviderId,
+    id: 'gpt-4.1-nano',
+    model: 'gpt-4.1-nano',
+  },
+  {
+    providerType: 'openai',
+    providerId: PROVIDER_TYPES_INFO.openai.defaultProviderId,
+    id: 'gpt-4o',
+    model: 'gpt-4o',
   },
   {
     providerType: 'openai',
@@ -281,8 +297,22 @@ export const DEFAULT_CHAT_MODELS: readonly ChatModel[] = [
   {
     providerType: 'openai',
     providerId: PROVIDER_TYPES_INFO.openai.defaultProviderId,
+    id: 'o4-mini',
+    model: 'o4-mini',
+    reasoning_effort: 'medium',
+  },
+  {
+    providerType: 'openai',
+    providerId: PROVIDER_TYPES_INFO.openai.defaultProviderId,
     id: 'o3-mini',
     model: 'o3-mini',
+    reasoning_effort: 'medium',
+  },
+  {
+    providerType: 'openai',
+    providerId: PROVIDER_TYPES_INFO.openai.defaultProviderId,
+    id: 'o3',
+    model: 'o3',
     reasoning_effort: 'medium',
   },
   {

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -14,6 +14,7 @@ type ModelPricing = {
 export const OPENAI_PRICES: Record<string, ModelPricing> = {
   'gpt-4o': { input: 2.5, output: 10 },
   'gpt-4o-mini': { input: 0.15, output: 0.6 },
+  'gpt-4.1': { input: 2.0, output: 8.0 },  // New GPT-4.1 pricing
   o1: { input: 15, output: 60 },
   'o3-mini': { input: 1.1, output: 4.4 },
   'o1-mini': { input: 1.1, output: 4.4 },
@@ -268,6 +269,12 @@ export const DEFAULT_CHAT_MODELS: readonly ChatModel[] = [
   {
     providerType: 'openai',
     providerId: PROVIDER_TYPES_INFO.openai.defaultProviderId,
+    id: 'gpt-4.1',
+    model: 'gpt-4.1',
+  },
+  {
+    providerType: 'openai',
+    providerId: PROVIDER_TYPES_INFO.openai.defaultProviderId,
     id: 'gpt-4o-mini',
     model: 'gpt-4o-mini',
   },
@@ -437,7 +444,7 @@ export const DEFAULT_EMBEDDING_MODELS: readonly EmbeddingModel[] = [
 ]
 
 // use ids
-export const RECOMMENDED_MODELS_FOR_CHAT = ['claude-3.7-sonnet', 'gpt-4o']
+export const RECOMMENDED_MODELS_FOR_CHAT = ['claude-3.7-sonnet', 'gpt-4o', 'gpt-4.1']
 export const RECOMMENDED_MODELS_FOR_APPLY = ['gpt-4o-mini']
 export const RECOMMENDED_MODELS_FOR_EMBEDDING = [
   'openai/text-embedding-3-small',

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -14,7 +14,7 @@ type ModelPricing = {
 export const OPENAI_PRICES: Record<string, ModelPricing> = {
   'gpt-4o': { input: 2.5, output: 10 },
   'gpt-4o-mini': { input: 0.15, output: 0.6 },
-  'gpt-4.1': { input: 2.0, output: 8.0 },  // New GPT-4.1 pricing
+  'gpt-4.1': { input: 2.0, output: 8.0 },
   o1: { input: 15, output: 60 },
   'o3-mini': { input: 1.1, output: 4.4 },
   'o1-mini': { input: 1.1, output: 4.4 },

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -304,22 +304,8 @@ export const DEFAULT_CHAT_MODELS: readonly ChatModel[] = [
   {
     providerType: 'openai',
     providerId: PROVIDER_TYPES_INFO.openai.defaultProviderId,
-    id: 'o3-mini',
-    model: 'o3-mini',
-    reasoning_effort: 'medium',
-  },
-  {
-    providerType: 'openai',
-    providerId: PROVIDER_TYPES_INFO.openai.defaultProviderId,
     id: 'o3',
     model: 'o3',
-    reasoning_effort: 'medium',
-  },
-  {
-    providerType: 'openai',
-    providerId: PROVIDER_TYPES_INFO.openai.defaultProviderId,
-    id: 'o1',
-    model: 'o1',
     reasoning_effort: 'medium',
   },
   {

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -13,8 +13,8 @@ type ModelPricing = {
 
 export const OPENAI_PRICES: Record<string, ModelPricing> = {
   'gpt-4.1': { input: 2.0, output: 8.0 },
-  'gpt-4.1-mini': { input: 0.40, output: 1.6 },
-  'gpt-4.1-nano': { input: 0.10, output: 0.40 },
+  'gpt-4.1-mini': { input: 0.4, output: 1.6 },
+  'gpt-4.1-nano': { input: 0.1, output: 0.4 },
   'gpt-4o': { input: 2.5, output: 10 },
   'gpt-4o-mini': { input: 0.15, output: 0.6 },
   o3: { input: 10, output: 40 },
@@ -474,7 +474,11 @@ export const DEFAULT_EMBEDDING_MODELS: readonly EmbeddingModel[] = [
 ]
 
 // use ids
-export const RECOMMENDED_MODELS_FOR_CHAT = ['claude-3.7-sonnet', 'gpt-4o', 'gpt-4.1']
+export const RECOMMENDED_MODELS_FOR_CHAT = [
+  'claude-3.7-sonnet',
+  'gpt-4o',
+  'gpt-4.1',
+]
 export const RECOMMENDED_MODELS_FOR_APPLY = ['gpt-4o-mini']
 export const RECOMMENDED_MODELS_FOR_EMBEDDING = [
   'openai/text-embedding-3-small',

--- a/src/settings/schema/migrations/6_to_7.ts
+++ b/src/settings/schema/migrations/6_to_7.ts
@@ -1,4 +1,5 @@
 import { SettingMigration } from '../setting.types'
+import { getMigratedProviders } from './migrationUtils';
 
 /**
  * Migration from version 6 to version 7
@@ -227,28 +228,7 @@ export const migrateFrom6To7: SettingMigration['migrate'] = (data) => {
   const newData = { ...data }
   newData.version = 7
 
-  if (!('providers' in newData && Array.isArray(newData.providers))) {
-    newData.providers = DEFAULT_PROVIDERS_V7
-  } else {
-    const defaultProviders = DEFAULT_PROVIDERS_V7.map((provider) => {
-      const existingProvider = (newData.providers as unknown[]).find(
-        (p: unknown) =>
-          (p as { type: string }).type === provider.type &&
-          (p as { id: string }).id === provider.id,
-      )
-      return existingProvider
-        ? Object.assign(existingProvider, provider)
-        : provider
-    })
-    const customProviders = (newData.providers as unknown[]).filter(
-      (p: unknown) =>
-        !defaultProviders.some(
-          (dp: unknown) =>
-            (dp as { id: string }).id === (p as { id: string }).id,
-        ),
-    )
-    newData.providers = [...defaultProviders, ...customProviders]
-  }
+  newData.providers = getMigratedProviders(newData, DEFAULT_PROVIDERS_V7);
 
   if (!('chatModels' in newData && Array.isArray(newData.chatModels))) {
     newData.chatModels = DEFAULT_CHAT_MODELS_V7

--- a/src/settings/schema/migrations/6_to_7.ts
+++ b/src/settings/schema/migrations/6_to_7.ts
@@ -1,5 +1,11 @@
 import { SettingMigration } from '../setting.types'
-import { DefaultChatModels, DefaultProviders, getMigratedChatModels, getMigratedProviders } from './migrationUtils';
+
+import {
+  DefaultChatModels,
+  DefaultProviders,
+  getMigratedChatModels,
+  getMigratedProviders,
+} from './migrationUtils'
 
 /**
  * Migration from version 6 to version 7
@@ -212,12 +218,8 @@ export const migrateFrom6To7: SettingMigration['migrate'] = (data) => {
   const newData = { ...data }
   newData.version = 7
 
-  newData.providers = getMigratedProviders(newData, DEFAULT_PROVIDERS_V7);
-  newData.chatModels = getMigratedChatModels(
-    newData,
-    DEFAULT_CHAT_MODELS_V7,
-  );
-
+  newData.providers = getMigratedProviders(newData, DEFAULT_PROVIDERS_V7)
+  newData.chatModels = getMigratedChatModels(newData, DEFAULT_CHAT_MODELS_V7)
 
   return newData
 }

--- a/src/settings/schema/migrations/7_to_8.test.ts
+++ b/src/settings/schema/migrations/7_to_8.test.ts
@@ -140,6 +140,12 @@ describe('settings 7_to_8 migration', () => {
           reasoning_effort: 'medium',
           enable: true,
         },
+        {
+          providerType: 'gemini',
+          providerId: 'gemini',
+          id: 'gemini-exp-1206',
+          model: 'gemini-exp-1206',
+        },
       ],
     };
 
@@ -154,6 +160,12 @@ describe('settings 7_to_8 migration', () => {
         }
         return model;
       }),
+      {
+        providerType: 'gemini',
+        providerId: 'gemini',
+        id: 'gemini-exp-1206',
+        model: 'gemini-exp-1206',
+      },
     ]);
   });
 });

--- a/src/settings/schema/migrations/7_to_8.test.ts
+++ b/src/settings/schema/migrations/7_to_8.test.ts
@@ -1,7 +1,7 @@
 import { migrateFrom7To8 } from './7_to_8'
 
 describe('settings 7_to_8 migration', () => {
-  it('should add gpt-4.1 model after gpt-4o', () => {
+  it('should add gpt-4.1 model before gpt-4o', () => {
     const oldSettings = {
       version: 7,
       chatModels: [
@@ -39,14 +39,14 @@ describe('settings 7_to_8 migration', () => {
       {
         providerType: 'openai',
         providerId: 'openai',
-        id: 'gpt-4o',
-        model: 'gpt-4o',
+        id: 'gpt-4.1',
+        model: 'gpt-4.1',
       },
       {
         providerType: 'openai',
         providerId: 'openai',
-        id: 'gpt-4.1',
-        model: 'gpt-4.1',
+        id: 'gpt-4o',
+        model: 'gpt-4o',
       },
       {
         providerType: 'openai',

--- a/src/settings/schema/migrations/7_to_8.test.ts
+++ b/src/settings/schema/migrations/7_to_8.test.ts
@@ -118,5 +118,42 @@ describe('settings 7_to_8 migration', () => {
     ];
 
     expect(migratedSettings.chatModels).toEqual(expectedDefaultAndCustomModels);
-  })
-})
+  });
+
+  it('should deprecate o3-mini and o1 models in favor of o4-mini and o3', () => {
+    const oldSettings = {
+      version: 7,
+      chatModels: [
+        {
+          providerType: 'openai',
+          providerId: 'openai',
+          id: 'o3-mini',
+          model: 'o3-mini',
+          reasoning_effort: 'medium',
+          enable: true,
+        },
+        {
+          providerType: 'openai',
+          providerId: 'openai',
+          id: 'o1',
+          model: 'o1',
+          reasoning_effort: 'medium',
+          enable: true,
+        },
+      ],
+    };
+
+    const migratedSettings = migrateFrom7To8(oldSettings)
+    expect(migratedSettings.chatModels).toEqual([
+      ...DEFAULT_CHAT_MODELS_V8.map((model) => {
+        if (model.id === 'o3-mini' || model.id === 'o1') {
+          return {
+            ...model,
+            enable: false,
+          };
+        }
+        return model;
+      }),
+    ]);
+  });
+});

--- a/src/settings/schema/migrations/7_to_8.test.ts
+++ b/src/settings/schema/migrations/7_to_8.test.ts
@@ -1,0 +1,131 @@
+import { migrateFrom7To8 } from './7_to_8'
+
+describe('settings 7_to_8 migration', () => {
+  it('should add gpt-4.1 model after gpt-4o', () => {
+    const oldSettings = {
+      version: 7,
+      chatModels: [
+        {
+          providerType: 'anthropic',
+          providerId: 'anthropic',
+          id: 'claude-3.7-sonnet',
+          model: 'claude-3-7-sonnet-latest',
+        },
+        {
+          providerType: 'openai',
+          providerId: 'openai',
+          id: 'gpt-4o',
+          model: 'gpt-4o',
+        },
+        {
+          providerType: 'openai',
+          providerId: 'openai',
+          id: 'gpt-4o-mini',
+          model: 'gpt-4o-mini',
+        },
+      ],
+      chatModelId: 'gpt-4o',
+    }
+
+    const result = migrateFrom7To8(oldSettings)
+    expect(result.version).toBe(8)
+    expect(result.chatModels).toEqual([
+      {
+        providerType: 'anthropic',
+        providerId: 'anthropic',
+        id: 'claude-3.7-sonnet',
+        model: 'claude-3-7-sonnet-latest',
+      },
+      {
+        providerType: 'openai',
+        providerId: 'openai',
+        id: 'gpt-4o',
+        model: 'gpt-4o',
+      },
+      {
+        providerType: 'openai',
+        providerId: 'openai',
+        id: 'gpt-4.1',
+        model: 'gpt-4.1',
+      },
+      {
+        providerType: 'openai',
+        providerId: 'openai',
+        id: 'gpt-4o-mini',
+        model: 'gpt-4o-mini',
+      },
+    ])
+    expect(result.chatModelId).toBe('gpt-4o')
+  })
+
+  it('should replace existing gpt-4.1 with new configuration', () => {
+    const oldSettings = {
+      version: 7,
+      chatModels: [
+        {
+          providerType: 'openai',
+          providerId: 'custom-provider',
+          id: 'gpt-4.1',
+          model: 'custom-model-name',
+          enable: false,
+        },
+      ],
+      chatModelId: 'gpt-4.1',
+    }
+
+    const result = migrateFrom7To8(oldSettings)
+    expect(result.version).toBe(8)
+    expect(result.chatModels).toEqual([
+      {
+        providerType: 'openai',
+        providerId: 'openai',
+        id: 'gpt-4.1',
+        model: 'gpt-4.1',
+      },
+    ])
+    expect(result.chatModelId).toBe('gpt-4.1')
+  })
+
+  it('should add after another OpenAI model if gpt-4o doesnt exist', () => {
+    const oldSettings = {
+      version: 7,
+      chatModels: [
+        {
+          providerType: 'anthropic',
+          providerId: 'anthropic',
+          id: 'claude-3.7-sonnet',
+          model: 'claude-3-7-sonnet-latest',
+        },
+        {
+          providerType: 'openai',
+          providerId: 'openai',
+          id: 'other-openai-model',
+          model: 'other-openai-model',
+        },
+      ],
+    }
+
+    const result = migrateFrom7To8(oldSettings)
+    expect(result.version).toBe(8)
+    expect(result.chatModels).toEqual([
+      {
+        providerType: 'anthropic',
+        providerId: 'anthropic',
+        id: 'claude-3.7-sonnet',
+        model: 'claude-3-7-sonnet-latest',
+      },
+      {
+        providerType: 'openai',
+        providerId: 'openai',
+        id: 'other-openai-model',
+        model: 'other-openai-model',
+      },
+      {
+        providerType: 'openai',
+        providerId: 'openai',
+        id: 'gpt-4.1',
+        model: 'gpt-4.1',
+      },
+    ])
+  })
+})

--- a/src/settings/schema/migrations/7_to_8.test.ts
+++ b/src/settings/schema/migrations/7_to_8.test.ts
@@ -1,3 +1,5 @@
+import { ChatModel } from '../../../types/chat-model.types'
+
 import { DEFAULT_CHAT_MODELS_V8, migrateFrom7To8 } from './7_to_8'
 
 describe('settings 7_to_8 migration', () => {
@@ -17,16 +19,13 @@ describe('settings 7_to_8 migration', () => {
       }
       const migratedSettings = migrateFrom7To8(oldSettings)
       expect(migratedSettings.version).toBe(8)
-      expect(migratedSettings.chatModels).not.toContainEqual(
-        expect.objectContaining({
-          id: 'o3-mini',
-        }),
+
+      // More succinct way to check for missing models with proper type annotation
+      const modelIds = (migratedSettings.chatModels as ChatModel[]).map(
+        (model: ChatModel) => model.id,
       )
-      expect(migratedSettings.chatModels).not.toContainEqual(
-        expect.objectContaining({
-          id: 'o1',
-        }),
-      )
+      expect(modelIds).not.toContain('o1')
+      expect(modelIds).not.toContain('o3-mini')
     })
   })
 

--- a/src/settings/schema/migrations/7_to_8.test.ts
+++ b/src/settings/schema/migrations/7_to_8.test.ts
@@ -6,9 +6,9 @@ describe('settings 7_to_8 migration', () => {
       version: 7,
     }
     const migratedSettings = migrateFrom7To8(oldSettings)
-    expect(migratedSettings.version).toBe(8);
-    expect(migratedSettings.chatModels).toEqual(DEFAULT_CHAT_MODELS_V8);
-  });
+    expect(migratedSettings.version).toBe(8)
+    expect(migratedSettings.chatModels).toEqual(DEFAULT_CHAT_MODELS_V8)
+  })
 
   it('should add default models and preserve custom models', () => {
     const oldSettings = {
@@ -28,7 +28,7 @@ describe('settings 7_to_8 migration', () => {
           enable: false,
         },
       ],
-    };
+    }
     const migratedSettings = migrateFrom7To8(oldSettings)
     expect(migratedSettings.chatModels).toEqual([
       ...DEFAULT_CHAT_MODELS_V8,
@@ -39,9 +39,8 @@ describe('settings 7_to_8 migration', () => {
         model: 'cohere-model',
         enable: false,
       },
-    ]);
-  });
-
+    ])
+  })
 
   it('should replace models that are in the new default models', () => {
     const oldSettings = {
@@ -89,7 +88,7 @@ describe('settings 7_to_8 migration', () => {
           model: 'gemini-exp-1206',
         },
       ],
-    };
+    }
 
     const migratedSettings = migrateFrom7To8(oldSettings)
     const expectedCustomDisabledModelIds = [
@@ -98,16 +97,16 @@ describe('settings 7_to_8 migration', () => {
       'gpt-4.1-nano',
       'o3',
       'o4-mini',
-    ];
+    ]
     const expectedDefaultAndCustomModels = [
       ...DEFAULT_CHAT_MODELS_V8.map((model) => {
         if (expectedCustomDisabledModelIds.includes(model.id)) {
           return {
             ...model,
             enable: false,
-          };
+          }
         }
-        return model;
+        return model
       }),
       {
         providerType: 'gemini',
@@ -115,10 +114,10 @@ describe('settings 7_to_8 migration', () => {
         id: 'gemini-exp-1206',
         model: 'gemini-exp-1206',
       },
-    ];
+    ]
 
-    expect(migratedSettings.chatModels).toEqual(expectedDefaultAndCustomModels);
-  });
+    expect(migratedSettings.chatModels).toEqual(expectedDefaultAndCustomModels)
+  })
 
   it('should deprecate o3-mini and o1 models in favor of o4-mini and o3', () => {
     const oldSettings = {
@@ -147,7 +146,7 @@ describe('settings 7_to_8 migration', () => {
           model: 'gemini-exp-1206',
         },
       ],
-    };
+    }
 
     const migratedSettings = migrateFrom7To8(oldSettings)
     expect(migratedSettings.chatModels).toEqual([
@@ -156,9 +155,9 @@ describe('settings 7_to_8 migration', () => {
           return {
             ...model,
             enable: false,
-          };
+          }
         }
-        return model;
+        return model
       }),
       {
         providerType: 'gemini',
@@ -166,6 +165,6 @@ describe('settings 7_to_8 migration', () => {
         id: 'gemini-exp-1206',
         model: 'gemini-exp-1206',
       },
-    ]);
-  });
-});
+    ])
+  })
+})

--- a/src/settings/schema/migrations/7_to_8.test.ts
+++ b/src/settings/schema/migrations/7_to_8.test.ts
@@ -1,25 +1,58 @@
 import { DEFAULT_CHAT_MODELS_V8, migrateFrom7To8 } from './7_to_8'
 
 describe('settings 7_to_8 migration', () => {
-  it('should use default chat models if chat models is not present', () => {
-    const oldSettings = {
-      version: 7,
-    }
-    const migratedSettings = migrateFrom7To8(oldSettings)
-    expect(migratedSettings.version).toBe(8)
-    expect(migratedSettings.chatModels).toEqual(DEFAULT_CHAT_MODELS_V8)
+  describe('when chat models are not present', () => {
+    it('should use default chat models', () => {
+      const oldSettings = {
+        version: 7,
+      }
+      const migratedSettings = migrateFrom7To8(oldSettings)
+      expect(migratedSettings.version).toBe(8)
+      expect(migratedSettings.chatModels).toEqual(DEFAULT_CHAT_MODELS_V8)
+    })
+
+    it('removes o3-mini and o1 models from the default chat models', () => {
+      const oldSettings = {
+        version: 7,
+      }
+      const migratedSettings = migrateFrom7To8(oldSettings)
+      expect(migratedSettings.version).toBe(8)
+      expect(migratedSettings.chatModels).not.toContainEqual(
+        expect.objectContaining({
+          id: 'o3-mini',
+        }),
+      )
+      expect(migratedSettings.chatModels).not.toContainEqual(
+        expect.objectContaining({
+          id: 'o1',
+        }),
+      )
+    })
   })
 
-  it('should add default models and preserve custom models', () => {
-    const oldSettings = {
-      version: 7,
-      chatModels: [
-        {
-          providerType: 'anthropic',
-          providerId: 'anthropic',
-          id: 'claude-3.7-sonnet',
-          model: 'claude-3-7-sonnet-latest',
-        },
+  describe('when existing chat models are present', () => {
+    it('should add default models and preserve custom models', () => {
+      const oldSettings = {
+        version: 7,
+        chatModels: [
+          {
+            providerType: 'anthropic',
+            providerId: 'anthropic',
+            id: 'claude-3.7-sonnet',
+            model: 'claude-3-7-sonnet-latest',
+          },
+          {
+            providerType: 'openai-compatible',
+            providerId: 'cohere',
+            id: 'cohere-model',
+            model: 'cohere-model',
+            enable: false,
+          },
+        ],
+      }
+      const migratedSettings = migrateFrom7To8(oldSettings)
+      expect(migratedSettings.chatModels).toEqual([
+        ...DEFAULT_CHAT_MODELS_V8,
         {
           providerType: 'openai-compatible',
           providerId: 'cohere',
@@ -27,102 +60,114 @@ describe('settings 7_to_8 migration', () => {
           model: 'cohere-model',
           enable: false,
         },
-      ],
-    }
-    const migratedSettings = migrateFrom7To8(oldSettings)
-    expect(migratedSettings.chatModels).toEqual([
-      ...DEFAULT_CHAT_MODELS_V8,
-      {
-        providerType: 'openai-compatible',
-        providerId: 'cohere',
-        id: 'cohere-model',
-        model: 'cohere-model',
-        enable: false,
-      },
-    ])
-  })
+      ])
+    })
 
-  it('should replace models that are in the new default models', () => {
-    const oldSettings = {
-      version: 7,
-      chatModels: [
-        {
-          providerType: 'openai',
-          providerId: 'openai',
-          id: 'gpt-4.1',
-          model: 'Custom gpt-4.1',
-          enable: false,
-        },
-        {
-          providerType: 'openai',
-          providerId: 'openai',
-          id: 'gpt-4.1-mini',
-          model: 'Custom gpt-4.1-mini',
-          enable: false,
-        },
-        {
-          providerType: 'openai',
-          providerId: 'openai',
-          id: 'gpt-4.1-nano',
-          model: 'Custom gpt-4.1-nano',
-          enable: false,
-        },
-        {
-          providerType: 'openai',
-          providerId: 'openai',
-          id: 'o3',
-          model: 'Custom o3',
-          enable: false,
-        },
-        {
-          providerType: 'openai',
-          providerId: 'openai',
-          id: 'o4-mini',
-          model: 'Custom o4-mini',
-          enable: false,
-        },
+    it('should replace models that are in the new default models', () => {
+      const oldSettings = {
+        version: 7,
+        chatModels: [
+          {
+            providerType: 'openai',
+            providerId: 'openai',
+            id: 'gpt-4.1',
+            model: 'Custom gpt-4.1',
+            enable: false,
+          },
+          {
+            providerType: 'openai',
+            providerId: 'openai',
+            id: 'gpt-4.1-mini',
+            model: 'Custom gpt-4.1-mini',
+            enable: false,
+          },
+          {
+            providerType: 'openai',
+            providerId: 'openai',
+            id: 'gpt-4.1-nano',
+            model: 'Custom gpt-4.1-nano',
+            enable: false,
+          },
+          {
+            providerType: 'openai',
+            providerId: 'openai',
+            id: 'o3',
+            model: 'Custom o3',
+            enable: false,
+          },
+          {
+            providerType: 'openai',
+            providerId: 'openai',
+            id: 'o4-mini',
+            model: 'Custom o4-mini',
+            enable: false,
+          },
+          {
+            providerType: 'gemini',
+            providerId: 'gemini',
+            id: 'gemini-exp-1206',
+            model: 'gemini-exp-1206',
+          },
+        ],
+      }
+
+      const migratedSettings = migrateFrom7To8(oldSettings)
+      const expectedCustomDisabledModelIds = [
+        'gpt-4.1',
+        'gpt-4.1-mini',
+        'gpt-4.1-nano',
+        'o3',
+        'o4-mini',
+      ]
+      const expectedDefaultAndCustomModels = [
+        ...DEFAULT_CHAT_MODELS_V8.map((model) => {
+          if (expectedCustomDisabledModelIds.includes(model.id)) {
+            return {
+              ...model,
+              enable: false,
+            }
+          }
+          return model
+        }),
         {
           providerType: 'gemini',
           providerId: 'gemini',
           id: 'gemini-exp-1206',
           model: 'gemini-exp-1206',
         },
-      ],
-    }
+      ]
 
-    const migratedSettings = migrateFrom7To8(oldSettings)
-    const expectedCustomDisabledModelIds = [
-      'gpt-4.1',
-      'gpt-4.1-mini',
-      'gpt-4.1-nano',
-      'o3',
-      'o4-mini',
-    ]
-    const expectedDefaultAndCustomModels = [
-      ...DEFAULT_CHAT_MODELS_V8.map((model) => {
-        if (expectedCustomDisabledModelIds.includes(model.id)) {
-          return {
-            ...model,
+      expect(migratedSettings.chatModels).toEqual(
+        expectedDefaultAndCustomModels,
+      )
+    })
+
+    it('keeps o3-mini and o1 models as custom models if they were already there', () => {
+      const oldSettings = {
+        version: 7,
+        chatModels: [
+          {
+            providerType: 'openai',
+            providerId: 'openai',
+            id: 'o3-mini',
+            model: 'o3-mini',
+            reasoning_effort: 'medium',
+            enable: true,
+          },
+          {
+            providerType: 'openai',
+            providerId: 'openai',
+            id: 'o1',
+            model: 'o1',
+            reasoning_effort: 'medium',
             enable: false,
-          }
-        }
-        return model
-      }),
-      {
-        providerType: 'gemini',
-        providerId: 'gemini',
-        id: 'gemini-exp-1206',
-        model: 'gemini-exp-1206',
-      },
-    ]
+          },
+        ],
+      }
 
-    expect(migratedSettings.chatModels).toEqual(expectedDefaultAndCustomModels)
-  })
-
-  it('should deprecate o3-mini and o1 models in favor of o4-mini and o3', () => {
-    const oldSettings = {
-      version: 7,
-      chatModels: [
+      const migratedSettings = migrateFrom7To8(oldSettings)
+      expect(migratedSettings.chatModels).toEqual([
+        ...DEFAULT_CHAT_MODELS_V8,
         {
           providerType: 'openai',
           providerId: 'openai',
@@ -137,34 +182,9 @@ describe('settings 7_to_8 migration', () => {
           id: 'o1',
           model: 'o1',
           reasoning_effort: 'medium',
-          enable: true,
+          enable: false,
         },
-        {
-          providerType: 'gemini',
-          providerId: 'gemini',
-          id: 'gemini-exp-1206',
-          model: 'gemini-exp-1206',
-        },
-      ],
-    }
-
-    const migratedSettings = migrateFrom7To8(oldSettings)
-    expect(migratedSettings.chatModels).toEqual([
-      ...DEFAULT_CHAT_MODELS_V8.map((model) => {
-        if (model.id === 'o3-mini' || model.id === 'o1') {
-          return {
-            ...model,
-            enable: false,
-          }
-        }
-        return model
-      }),
-      {
-        providerType: 'gemini',
-        providerId: 'gemini',
-        id: 'gemini-exp-1206',
-        model: 'gemini-exp-1206',
-      },
-    ])
+      ])
+    })
   })
 })

--- a/src/settings/schema/migrations/7_to_8.ts
+++ b/src/settings/schema/migrations/7_to_8.ts
@@ -2,52 +2,6 @@ import { PROVIDER_TYPES_INFO } from '../../../constants'
 import { SettingMigration } from '../setting.types'
 import { DefaultChatModels, getMigratedChatModels, getMigratedProviders } from './migrationUtils';
 
-export const DEFAULT_PROVIDERS_V8: readonly {
-  type: string
-  id: string
-}[] = [
-  {
-    type: 'openai',
-    id: 'openai',
-  },
-  {
-    type: 'anthropic',
-    id: 'anthropic',
-  },
-  {
-    type: 'gemini',
-    id: 'gemini',
-  },
-  {
-    type: 'deepseek',
-    id: 'deepseek',
-  },
-  {
-    type: 'perplexity',
-    id: 'perplexity',
-  },
-  {
-    type: 'groq',
-    id: 'groq',
-  },
-  {
-    type: 'openrouter',
-    id: 'openrouter',
-  },
-  {
-    type: 'ollama',
-    id: 'ollama',
-  },
-  {
-    type: 'lm-studio',
-    id: 'lm-studio',
-  },
-  {
-    type: 'morph',
-    id: 'morph',
-  },
-];
-
 export const DEFAULT_CHAT_MODELS_V8: DefaultChatModels = [
   {
     providerType: 'anthropic',
@@ -255,7 +209,6 @@ export const migrateFrom7To8: SettingMigration['migrate'] = (data) => {
   const newData = { ...data }
   newData.version = 8
 
-  newData.providers = getMigratedProviders(newData, DEFAULT_PROVIDERS_V8);
   newData.chatModels = getMigratedChatModels(
     newData,
     DEFAULT_CHAT_MODELS_V8,

--- a/src/settings/schema/migrations/7_to_8.ts
+++ b/src/settings/schema/migrations/7_to_8.ts
@@ -1,5 +1,52 @@
 import { PROVIDER_TYPES_INFO } from '../../../constants'
 import { SettingMigration } from '../setting.types'
+import { getMigratedProviders } from './migrationUtils';
+
+export const DEFAULT_PROVIDERS_V8: readonly {
+  type: string
+  id: string
+}[] = [
+  {
+    type: 'openai',
+    id: 'openai',
+  },
+  {
+    type: 'anthropic',
+    id: 'anthropic',
+  },
+  {
+    type: 'gemini',
+    id: 'gemini',
+  },
+  {
+    type: 'deepseek',
+    id: 'deepseek',
+  },
+  {
+    type: 'perplexity',
+    id: 'perplexity',
+  },
+  {
+    type: 'groq',
+    id: 'groq',
+  },
+  {
+    type: 'openrouter',
+    id: 'openrouter',
+  },
+  {
+    type: 'ollama',
+    id: 'ollama',
+  },
+  {
+    type: 'lm-studio',
+    id: 'lm-studio',
+  },
+  {
+    type: 'morph',
+    id: 'morph',
+  },
+]
 
 /**
  * Migration from version 7 to version 8
@@ -8,6 +55,8 @@ import { SettingMigration } from '../setting.types'
 export const migrateFrom7To8: SettingMigration['migrate'] = (data) => {
   const newData = { ...data }
   newData.version = 8
+
+  newData.providers = getMigratedProviders(newData, DEFAULT_PROVIDERS_V8);
 
   if ('chatModels' in newData && Array.isArray(newData.chatModels)) {
     const existingModelsMap = new Map(

--- a/src/settings/schema/migrations/7_to_8.ts
+++ b/src/settings/schema/migrations/7_to_8.ts
@@ -1,0 +1,57 @@
+import { PROVIDER_TYPES_INFO } from '../../../constants'
+import { SettingMigration } from '../setting.types'
+
+/**
+ * Migration from version 7 to version 8
+ * - Add gpt-4.1 model
+ */
+export const migrateFrom7To8: SettingMigration['migrate'] = (data) => {
+  const newData = { ...data }
+  newData.version = 8
+
+  if ('chatModels' in newData && Array.isArray(newData.chatModels)) {
+    const existingModelsMap = new Map(
+      newData.chatModels.map((model) => [model.id, model]),
+    )
+
+    const newModel = {
+      providerType: 'openai',
+      providerId: PROVIDER_TYPES_INFO.openai.defaultProviderId,
+      id: 'gpt-4.1',
+      model: 'gpt-4.1',
+    }
+
+    // Override existing model with same id if it exists
+    const existingModel = existingModelsMap.get(newModel.id)
+    if (existingModel) {
+      // Remove the existing model from the array
+      newData.chatModels = newData.chatModels.filter(
+        (model) => model.id !== newModel.id,
+      )
+    }
+
+    // Find the position after gpt-4o to insert the new model
+    const gpt4oIndex = newData.chatModels.findIndex(
+      (model) => model.id === 'gpt-4o'
+    )
+    
+    if (gpt4oIndex !== -1) {
+      // Insert after gpt-4o
+      (newData.chatModels as unknown[]).splice(gpt4oIndex + 1, 0, newModel)
+    } else {
+      // If gpt-4o doesn't exist, find any OpenAI model to insert after
+      const openaiModelIndex = newData.chatModels.findIndex(
+        (model) => model.providerType === 'openai'
+      )
+      
+      if (openaiModelIndex !== -1) {
+        (newData.chatModels as unknown[]).splice(openaiModelIndex + 1, 0, newModel)
+      } else {
+        // As a last resort, add to the end
+        (newData.chatModels as unknown[]).push(newModel)
+      }
+    }
+  }
+
+  return newData
+}

--- a/src/settings/schema/migrations/7_to_8.ts
+++ b/src/settings/schema/migrations/7_to_8.ts
@@ -1,4 +1,3 @@
-import { PROVIDER_TYPES_INFO } from '../../../constants'
 import { SettingMigration } from '../setting.types'
 import { DefaultChatModels, getMigratedChatModels, getMigratedProviders } from './migrationUtils';
 

--- a/src/settings/schema/migrations/7_to_8.ts
+++ b/src/settings/schema/migrations/7_to_8.ts
@@ -1,6 +1,6 @@
 import { PROVIDER_TYPES_INFO } from '../../../constants'
 import { SettingMigration } from '../setting.types'
-import { getMigratedProviders } from './migrationUtils';
+import { DefaultChatModels, getMigratedChatModels, getMigratedProviders } from './migrationUtils';
 
 export const DEFAULT_PROVIDERS_V8: readonly {
   type: string
@@ -46,66 +46,220 @@ export const DEFAULT_PROVIDERS_V8: readonly {
     type: 'morph',
     id: 'morph',
   },
+];
+
+export const DEFAULT_CHAT_MODELS_V8: DefaultChatModels = [
+  {
+    providerType: 'anthropic',
+    providerId: 'anthropic',
+    id: 'claude-3.7-sonnet',
+    model: 'claude-3-7-sonnet-latest',
+  },
+  {
+    providerType: 'anthropic',
+    providerId: 'anthropic',
+    id: 'claude-3.7-sonnet-thinking',
+    model: 'claude-3-7-sonnet-latest',
+    thinking: {
+      budget_tokens: 8192,
+    },
+  },
+  {
+    providerType: 'anthropic',
+    providerId: 'anthropic',
+    id: 'claude-3.5-sonnet',
+    model: 'claude-3-5-sonnet-latest',
+  },
+  {
+    providerType: 'anthropic',
+    providerId: 'anthropic',
+    id: 'claude-3.5-haiku',
+    model: 'claude-3-5-haiku-latest',
+  },
+  {
+    // New
+    providerType: 'openai',
+    providerId: 'openai',
+    id: 'gpt-4.1',
+    model: 'gpt-4.1',
+  },
+  {
+    // New
+    providerType: 'openai',
+    providerId: 'openai',
+    id: 'gpt-4.1-mini',
+    model: 'gpt-4.1-mini',
+  },
+  {
+    // New
+    providerType: 'openai',
+    providerId: 'openai',
+    id: 'gpt-4.1-nano',
+    model: 'gpt-4.1-nano',
+  },
+  {
+    providerType: 'openai',
+    providerId: 'openai',
+    id: 'gpt-4o',
+    model: 'gpt-4o',
+  },
+  {
+    providerType: 'openai',
+    providerId: 'openai',
+    id: 'gpt-4o-mini',
+    model: 'gpt-4o-mini',
+  },
+  {
+    // New
+    providerType: 'openai',
+    providerId: 'openai',
+    id: 'o4-mini',
+    model: 'o4-mini',
+    reasoning_effort: 'medium',
+  },
+  {
+    providerType: 'openai',
+    providerId: 'openai',
+    id: 'o3-mini',
+    model: 'o3-mini',
+    reasoning_effort: 'medium',
+    enable: false, // Deprecate in favor of o4-mini
+  },
+  {
+    // New
+    providerType: 'openai',
+    providerId: 'openai',
+    id: 'o3',
+    model: 'o3',
+    reasoning_effort: 'medium',
+  },
+  {
+    providerType: 'openai',
+    providerId: 'openai',
+    id: 'o1',
+    model: 'o1',
+    reasoning_effort: 'medium',
+    enable: false, // Deprecate in favor of o3
+  },
+  {
+    providerType: 'gemini',
+    providerId: 'gemini',
+    id: 'gemini-2.5-pro',
+    model: 'gemini-2.5-pro-preview-03-25',
+  },
+  {
+    providerType: 'gemini',
+    providerId: 'gemini',
+    id: 'gemini-2.0-flash',
+    model: 'gemini-2.0-flash',
+  },
+  {
+    providerType: 'gemini',
+    providerId: 'gemini',
+    id: 'gemini-2.0-flash-thinking',
+    model: 'gemini-2.0-flash-thinking-exp',
+  },
+  {
+    providerType: 'gemini',
+    providerId: 'gemini',
+    id: 'gemini-2.0-flash-lite',
+    model: 'gemini-2.0-flash-lite',
+  },
+  {
+    providerType: 'gemini',
+    providerId: 'gemini',
+    id: 'gemini-1.5-pro',
+    model: 'gemini-1.5-pro',
+  },
+  {
+    providerType: 'gemini',
+    providerId: 'gemini',
+    id: 'gemini-1.5-flash',
+    model: 'gemini-1.5-flash',
+  },
+  {
+    providerType: 'deepseek',
+    providerId: 'deepseek',
+    id: 'deepseek-chat',
+    model: 'deepseek-chat',
+  },
+  {
+    providerType: 'deepseek',
+    providerId: 'deepseek',
+    id: 'deepseek-reasoner',
+    model: 'deepseek-reasoner',
+  },
+  {
+    providerType: 'perplexity',
+    providerId: 'perplexity',
+    id: 'sonar',
+    model: 'sonar',
+    web_search_options: {
+      search_context_size: 'low',
+    },
+  },
+  {
+    providerType: 'perplexity',
+    providerId: 'perplexity',
+    id: 'sonar-pro',
+    model: 'sonar',
+    web_search_options: {
+      search_context_size: 'low',
+    },
+  },
+  {
+    providerType: 'perplexity',
+    providerId: 'perplexity',
+    id: 'sonar-deep-research',
+    model: 'sonar-deep-research',
+    web_search_options: {
+      search_context_size: 'low',
+    },
+  },
+  {
+    providerType: 'perplexity',
+    providerId: 'perplexity',
+    id: 'sonar-reasoning',
+    model: 'sonar',
+    web_search_options: {
+      search_context_size: 'low',
+    },
+  },
+  {
+    providerType: 'perplexity',
+    providerId: 'perplexity',
+    id: 'sonar-reasoning-pro',
+    model: 'sonar',
+    web_search_options: {
+      search_context_size: 'low',
+    },
+  },
+  {
+    providerType: 'morph',
+    providerId: 'morph',
+    id: 'morph-v0',
+    model: 'morph-v0',
+  },
 ]
 
 /**
  * Migration from version 7 to version 8
- * - Add gpt-4.1 model
+ * - Add the following models:
+ *   - gpt-4.1
+ *   - gpt-4.1-mini
+ *   - gpt-4.1-nano
+ *   - o3
+ *   - o4-mini
  */
 export const migrateFrom7To8: SettingMigration['migrate'] = (data) => {
   const newData = { ...data }
   newData.version = 8
 
   newData.providers = getMigratedProviders(newData, DEFAULT_PROVIDERS_V8);
-
-  if ('chatModels' in newData && Array.isArray(newData.chatModels)) {
-    const existingModelsMap = new Map(
-      newData.chatModels.map((model) => [model.id, model]),
-    )
-
-    const newModel = {
-      providerType: 'openai',
-      providerId: PROVIDER_TYPES_INFO.openai.defaultProviderId,
-      id: 'gpt-4.1',
-      model: 'gpt-4.1',
-    }
-
-    // Override existing model with same id if it exists
-    const existingModel = existingModelsMap.get(newModel.id)
-    if (existingModel) {
-      // Remove the existing model from the array
-      newData.chatModels = newData.chatModels.filter(
-        (model) => model.id !== newModel.id,
-      )
-    }
-
-    // Find the position of gpt-4o model to insert before it
-    const gpt4oIndex = (newData.chatModels as unknown[]).findIndex(
-      (model: unknown) => {
-        return (model as { id: string }).id === 'gpt-4o'
-      }
-    )
-
-    if (gpt4oIndex !== -1) {
-      // Insert before gpt-4o
-      (newData.chatModels as unknown[]).splice(gpt4oIndex, 0, newModel)
-    } else {
-      // If gpt-4o doesn't exist, find any OpenAI model
-      const openaiModelIndex = (newData.chatModels as unknown[]).findIndex(
-        (model: unknown) => {
-          return (model as { providerType: string }).providerType === 'openai'
-        }
-      )
-
-      if (openaiModelIndex !== -1) {
-        // Add after the first OpenAI model found
-        (newData.chatModels as unknown[]).splice(openaiModelIndex + 1, 0, newModel)
-      } else {
-        // As a last resort, add to the end
-        (newData.chatModels as unknown[]).push(newModel)
-      }
-    }
-  }
+  newData.chatModels = getMigratedChatModels(
+    newData,
+    DEFAULT_CHAT_MODELS_V8,
+  );
 
   return newData
 }

--- a/src/settings/schema/migrations/7_to_8.ts
+++ b/src/settings/schema/migrations/7_to_8.ts
@@ -30,21 +30,26 @@ export const migrateFrom7To8: SettingMigration['migrate'] = (data) => {
       )
     }
 
-    // Find the position after gpt-4o to insert the new model
-    const gpt4oIndex = newData.chatModels.findIndex(
-      (model) => model.id === 'gpt-4o'
+    // Find the position of gpt-4o model to insert before it
+    const gpt4oIndex = (newData.chatModels as unknown[]).findIndex(
+      (model: unknown) => {
+        return (model as { id: string }).id === 'gpt-4o'
+      }
     )
-    
+
     if (gpt4oIndex !== -1) {
-      // Insert after gpt-4o
-      (newData.chatModels as unknown[]).splice(gpt4oIndex + 1, 0, newModel)
+      // Insert before gpt-4o
+      (newData.chatModels as unknown[]).splice(gpt4oIndex, 0, newModel)
     } else {
-      // If gpt-4o doesn't exist, find any OpenAI model to insert after
-      const openaiModelIndex = newData.chatModels.findIndex(
-        (model) => model.providerType === 'openai'
+      // If gpt-4o doesn't exist, find any OpenAI model
+      const openaiModelIndex = (newData.chatModels as unknown[]).findIndex(
+        (model: unknown) => {
+          return (model as { providerType: string }).providerType === 'openai'
+        }
       )
-      
+
       if (openaiModelIndex !== -1) {
+        // Add after the first OpenAI model found
         (newData.chatModels as unknown[]).splice(openaiModelIndex + 1, 0, newModel)
       } else {
         // As a last resort, add to the end

--- a/src/settings/schema/migrations/7_to_8.ts
+++ b/src/settings/schema/migrations/7_to_8.ts
@@ -203,6 +203,9 @@ export const DEFAULT_CHAT_MODELS_V8: DefaultChatModels = [
  *   - gpt-4.1-nano
  *   - o3
  *   - o4-mini
+ * - Disable the following deprecated models:
+ *   - o1
+ *   - o3-mini
  */
 export const migrateFrom7To8: SettingMigration['migrate'] = (data) => {
   const newData = { ...data }

--- a/src/settings/schema/migrations/7_to_8.ts
+++ b/src/settings/schema/migrations/7_to_8.ts
@@ -1,5 +1,6 @@
 import { SettingMigration } from '../setting.types'
-import { DefaultChatModels, getMigratedChatModels, getMigratedProviders } from './migrationUtils';
+
+import { DefaultChatModels, getMigratedChatModels } from './migrationUtils'
 
 export const DEFAULT_CHAT_MODELS_V8: DefaultChatModels = [
   {
@@ -211,10 +212,7 @@ export const migrateFrom7To8: SettingMigration['migrate'] = (data) => {
   const newData = { ...data }
   newData.version = 8
 
-  newData.chatModels = getMigratedChatModels(
-    newData,
-    DEFAULT_CHAT_MODELS_V8,
-  );
+  newData.chatModels = getMigratedChatModels(newData, DEFAULT_CHAT_MODELS_V8)
 
   return newData
 }

--- a/src/settings/schema/migrations/7_to_8.ts
+++ b/src/settings/schema/migrations/7_to_8.ts
@@ -72,28 +72,12 @@ export const DEFAULT_CHAT_MODELS_V8: DefaultChatModels = [
     reasoning_effort: 'medium',
   },
   {
-    providerType: 'openai',
-    providerId: 'openai',
-    id: 'o3-mini',
-    model: 'o3-mini',
-    reasoning_effort: 'medium',
-    enable: false, // Deprecate in favor of o4-mini
-  },
-  {
     // New
     providerType: 'openai',
     providerId: 'openai',
     id: 'o3',
     model: 'o3',
     reasoning_effort: 'medium',
-  },
-  {
-    providerType: 'openai',
-    providerId: 'openai',
-    id: 'o1',
-    model: 'o1',
-    reasoning_effort: 'medium',
-    enable: false, // Deprecate in favor of o3
   },
   {
     providerType: 'gemini',

--- a/src/settings/schema/migrations/index.ts
+++ b/src/settings/schema/migrations/index.ts
@@ -7,8 +7,9 @@ import { migrateFrom3To4 } from './3_to_4'
 import { migrateFrom4To5 } from './4_to_5'
 import { migrateFrom5To6 } from './5_to_6'
 import { migrateFrom6To7 } from './6_to_7'
+import { migrateFrom7To8 } from './7_to_8'
 
-export const SETTINGS_SCHEMA_VERSION = 7
+export const SETTINGS_SCHEMA_VERSION = 8
 
 export const SETTING_MIGRATIONS: SettingMigration[] = [
   {
@@ -45,5 +46,10 @@ export const SETTING_MIGRATIONS: SettingMigration[] = [
     fromVersion: 6,
     toVersion: 7,
     migrate: migrateFrom6To7,
+  },
+  {
+    fromVersion: 7,
+    toVersion: 8,
+    migrate: migrateFrom7To8,
   },
 ]

--- a/src/settings/schema/migrations/migrationUtils.ts
+++ b/src/settings/schema/migrations/migrationUtils.ts
@@ -1,0 +1,32 @@
+import { SettingMigration } from "../setting.types";
+
+type ExistingSettingsData = Parameters<SettingMigration['migrate']>[0];
+type DefaultProviders = readonly {
+  type: string
+  id: string
+}[];
+
+export const getMigratedProviders = (existingData: ExistingSettingsData, defaultProvidersForVersion: DefaultProviders) => {
+  if (!('providers' in existingData && Array.isArray(existingData.providers))) {
+    return defaultProvidersForVersion;
+  }
+
+  const defaultProviders = defaultProvidersForVersion.map((provider) => {
+    const existingProvider = (existingData.providers as unknown[]).find(
+      (p: unknown) =>
+        (p as { type: string }).type === provider.type &&
+        (p as { id: string }).id === provider.id,
+    )
+    return existingProvider
+      ? Object.assign(existingProvider, provider)
+      : provider
+  })
+  const customProviders = (existingData.providers as unknown[]).filter(
+    (p: unknown) =>
+      !defaultProviders.some(
+        (dp: unknown) =>
+          (dp as { id: string }).id === (p as { id: string }).id,
+      ),
+  )
+  return [...defaultProviders, ...customProviders];
+}

--- a/src/settings/schema/migrations/migrationUtils.ts
+++ b/src/settings/schema/migrations/migrationUtils.ts
@@ -1,14 +1,17 @@
-import { SettingMigration } from "../setting.types";
+import { SettingMigration } from '../setting.types'
 
-export type ExistingSettingsData = Parameters<SettingMigration['migrate']>[0];
+export type ExistingSettingsData = Parameters<SettingMigration['migrate']>[0]
 export type DefaultProviders = readonly {
   type: string
   id: string
-}[];
+}[]
 
-export const getMigratedProviders = (existingData: ExistingSettingsData, defaultProvidersForVersion: DefaultProviders) => {
+export const getMigratedProviders = (
+  existingData: ExistingSettingsData,
+  defaultProvidersForVersion: DefaultProviders,
+) => {
   if (!('providers' in existingData && Array.isArray(existingData.providers))) {
-    return defaultProvidersForVersion;
+    return defaultProvidersForVersion
   }
 
   const defaultProviders = defaultProvidersForVersion.map((provider) => {
@@ -24,12 +27,11 @@ export const getMigratedProviders = (existingData: ExistingSettingsData, default
   const customProviders = (existingData.providers as unknown[]).filter(
     (p: unknown) =>
       !defaultProviders.some(
-        (dp: unknown) =>
-          (dp as { id: string }).id === (p as { id: string }).id,
+        (dp: unknown) => (dp as { id: string }).id === (p as { id: string }).id,
       ),
   )
 
-  return [...defaultProviders, ...customProviders];
+  return [...defaultProviders, ...customProviders]
 }
 
 export type DefaultChatModels = {
@@ -45,15 +47,16 @@ export type DefaultChatModels = {
     search_context_size?: string
   }
   enable?: boolean
-}[];
+}[]
 
 export const getMigratedChatModels = (
   existingData: ExistingSettingsData,
   defaultChatModelsForVersion: DefaultChatModels,
 ) => {
-
-  if (!('chatModels' in existingData && Array.isArray(existingData.chatModels))) {
-    return defaultChatModelsForVersion;
+  if (
+    !('chatModels' in existingData && Array.isArray(existingData.chatModels))
+  ) {
+    return defaultChatModelsForVersion
   }
 
   const defaultChatModels = defaultChatModelsForVersion.map((model) => {
@@ -70,11 +73,10 @@ export const getMigratedChatModels = (
   const customChatModels = (existingData.chatModels as unknown[]).filter(
     (m: unknown) => {
       return !defaultChatModels.some(
-        (dm: unknown) =>
-          (dm as { id: string }).id === (m as { id: string }).id,
+        (dm: unknown) => (dm as { id: string }).id === (m as { id: string }).id,
       )
     },
   )
 
-  return [...defaultChatModels, ...customChatModels];
+  return [...defaultChatModels, ...customChatModels]
 }


### PR DESCRIPTION
## Description

Fixes #356.

Adds support for the latest OpenAI models, including:
- gpt-4.1
- gpt-4.1-mini
- gpt-4.1-nano
- o3
- o4-mini

For the migrations, extracts a couple utility functions that could be more easily used by future migrations to follow the same pattern for migrating providers and chat models.

## Checklist before requesting a review
- [X] I have reviewed the [guidelines for contributing](../CONTRIBUTING.md) to this repository.
- [X] I have performed a self-review of my code
- [X] I have performed a code linting check and type check (by running `npm run lint:check` and `npm run type:check`)
- [X] I have run the test suite (by running `npm run test`)
- [X] I have tested the functionality manually
  - I do not have access to o3, so I could not test that, but I tested the others.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for new OpenAI models including GPT-4.1 variants, o3, and o4-mini with updated pricing and default chat model options.
  - Expanded recommended models list to include GPT-4.1.

- **Bug Fixes**
  - Disabled deprecated models during settings migration to improve handling of outdated options.

- **Chores**
  - Refined settings migration process with utility functions for merging providers and chat models, ensuring smooth upgrades and better configuration management.
  - Introduced tests to verify migration logic from version 7 to 8.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->