### PR TITLE
feat: Add current file inclusion/exclusion toggle

### DIFF
--- a/src/components/chat-view/chat-input/ChatUserInput.tsx
+++ b/src/components/chat-view/chat-input/ChatUserInput.tsx
@@ -11,7 +11,6 @@ import {
 } from 'react'
 
 import { useApp } from '../../../contexts/app-context'
-import { useDarkModeContext } from '../../../contexts/dark-mode-context'
 import {
   Mentionable,
   MentionableImage,
@@ -24,7 +23,7 @@ import {
 } from '../../../utils/chat/mentionable'
 import { fileToMentionableImage } from '../../../utils/llm/image'
 import { openMarkdownFile, readTFileContent } from '../../../utils/obsidian'
-import { MemoizedSyntaxHighlighterWrapper } from '../SyntaxHighlighterWrapper'
+import ObsidianMarkdown from '../ObsidianMarkdown'
 
 import { ImageUploadButton } from './ImageUploadButton'
 import LexicalContentEditable from './LexicalContentEditable'
@@ -299,7 +298,6 @@ function MentionableContentPreview({
   mentionables: Mentionable[]
 }) {
   const app = useApp()
-  const { isDarkMode } = useDarkModeContext()
 
   const displayedMentionable: Mentionable | null = useMemo(() => {
     return (
@@ -353,14 +351,7 @@ function MentionableContentPreview({
 
   return displayFileContent ? (
     <div className="smtcmp-chat-user-input-file-content-preview">
-      <MemoizedSyntaxHighlighterWrapper
-        isDarkMode={isDarkMode}
-        language="markdown"
-        hasFilename={false}
-        wrapLines={false}
-      >
-        {displayFileContent}
-      </MemoizedSyntaxHighlighterWrapper>
+      <ObsidianMarkdown content={displayFileContent} scale="xs" />
     </div>
   ) : displayImage ? (
     <div className="smtcmp-chat-user-input-file-content-preview">

--- a/src/components/chat-view/chat-input/MentionableBadge.tsx
+++ b/src/components/chat-view/chat-input/MentionableBadge.tsx
@@ -1,6 +1,8 @@
-import { X } from 'lucide-react'
+import clsx from 'clsx'
+import { Eye, EyeOff, X } from 'lucide-react'
 import { PropsWithChildren } from 'react'
 
+import { useSettings } from '../../../contexts/settings-context'
 import {
   Mentionable,
   MentionableBlock,
@@ -37,7 +39,7 @@ function BadgeBase({
           onDelete()
         }}
       >
-        <X size={10} />
+        <X size={12} />
       </div>
     </div>
   )
@@ -60,7 +62,7 @@ function FileBadge({
       <div className="smtcmp-chat-user-input-file-badge-name">
         {Icon && (
           <Icon
-            size={10}
+            size={12}
             className="smtcmp-chat-user-input-file-badge-name-icon"
           />
         )}
@@ -87,7 +89,7 @@ function FolderBadge({
       <div className="smtcmp-chat-user-input-file-badge-name">
         {Icon && (
           <Icon
-            size={10}
+            size={12}
             className="smtcmp-chat-user-input-file-badge-name-icon"
           />
         )}
@@ -112,11 +114,10 @@ function VaultBadge({
   const Icon = getMentionableIcon(mentionable)
   return (
     <BadgeBase onDelete={onDelete} onClick={onClick} isFocused={isFocused}>
-      {/* TODO: Update style */}
       <div className="smtcmp-chat-user-input-file-badge-name">
         {Icon && (
           <Icon
-            size={10}
+            size={12}
             className="smtcmp-chat-user-input-file-badge-name-icon"
           />
         )}
@@ -137,20 +138,49 @@ function CurrentFileBadge({
   onClick: () => void
   isFocused: boolean
 }) {
+  const { settings, setSettings } = useSettings()
+
   const Icon = getMentionableIcon(mentionable)
   return mentionable.file ? (
     <BadgeBase onDelete={onDelete} onClick={onClick} isFocused={isFocused}>
       <div className="smtcmp-chat-user-input-file-badge-name">
         {Icon && (
           <Icon
-            size={10}
+            size={12}
             className="smtcmp-chat-user-input-file-badge-name-icon"
           />
         )}
-        <span>{mentionable.file.name}</span>
+        <span
+          className={clsx(
+            !settings.includeCurrentFileContent && 'smtcmp-excluded-content',
+          )}
+        >
+          {mentionable.file.name}
+        </span>
       </div>
-      <div className="smtcmp-chat-user-input-file-badge-name-suffix">
+      <div
+        className={clsx(
+          'smtcmp-chat-user-input-file-badge-name-suffix',
+          !settings.includeCurrentFileContent && 'smtcmp-excluded-content',
+        )}
+      >
         {' (Current File)'}
+      </div>
+      <div
+        className="smtcmp-chat-user-input-file-badge-eye"
+        onClick={(e) => {
+          e.stopPropagation()
+          setSettings({
+            ...settings,
+            includeCurrentFileContent: !settings.includeCurrentFileContent,
+          })
+        }}
+      >
+        {settings.includeCurrentFileContent ? (
+          <Eye size={12} />
+        ) : (
+          <EyeOff size={12} />
+        )}
       </div>
     </BadgeBase>
   ) : null
@@ -173,7 +203,7 @@ function BlockBadge({
       <div className="smtcmp-chat-user-input-file-badge-name">
         {Icon && (
           <Icon
-            size={10}
+            size={12}
             className="smtcmp-chat-user-input-file-badge-name-icon"
           />
         )}
@@ -203,7 +233,7 @@ function UrlBadge({
       <div className="smtcmp-chat-user-input-file-badge-name">
         {Icon && (
           <Icon
-            size={10}
+            size={12}
             className="smtcmp-chat-user-input-file-badge-name-icon"
           />
         )}
@@ -230,7 +260,7 @@ function ImageBadge({
       <div className="smtcmp-chat-user-input-file-badge-name">
         {Icon && (
           <Icon
-            size={10}
+            size={12}
             className="smtcmp-chat-user-input-file-badge-name-icon"
           />
         )}

--- a/src/settings/schema/setting.types.ts
+++ b/src/settings/schema/setting.types.ts
@@ -57,6 +57,8 @@ export const smartComposerSettingsSchema = z.object({
     excludePatterns: [],
     includePatterns: [],
   }),
+
+  includeCurrentFileContent: z.boolean().catch(true),
 })
 export type SmartComposerSettings = z.infer<typeof smartComposerSettingsSchema>
 

--- a/src/settings/schema/settings.test.ts
+++ b/src/settings/schema/settings.test.ts
@@ -32,6 +32,8 @@ describe('parseSmartComposerSettings', () => {
         excludePatterns: [],
         includePatterns: [],
       },
+
+      includeCurrentFileContent: true,
     })
   })
 })

--- a/src/utils/chat/promptGenerator.ts
+++ b/src/utils/chat/promptGenerator.ts
@@ -104,9 +104,10 @@ export class PromptGenerator {
     const currentFile = lastUserMessage.mentionables.find(
       (m) => m.type === 'current-file',
     )?.file
-    const currentFileMessage = currentFile
-      ? await this.getCurrentFileMessage(currentFile)
-      : undefined
+    const currentFileMessage =
+      currentFile && this.settings.includeCurrentFileContent
+        ? await this.getCurrentFileMessage(currentFile)
+        : undefined
 
     const requestMessages: RequestMessage[] = [
       systemMessage,

--- a/styles.css
+++ b/styles.css
@@ -291,21 +291,34 @@ button:not(.clickable-icon).smtcmp-chat-list-dropdown {
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
+  cursor: pointer;
 
   &.smtcmp-chat-user-input-file-badge-focused {
     border: 1px solid var(--interactive-accent);
+  }
+
+  .smtcmp-excluded-content {
+    text-decoration: line-through;
+    font-style: italic;
   }
 }
 
 .smtcmp-chat-user-input-file-badge:hover {
   background-color: var(--background-modifier-hover);
-  cursor: pointer;
 }
 
 .smtcmp-chat-user-input-file-badge-delete {
-  cursor: pointer;
+  height: 100%;
   display: flex;
+  align-items: center;
   color: var(--text-muted);
+}
+
+.smtcmp-chat-user-input-file-badge-eye {
+  height: 100%;
+  display: flex;
+  align-items: center;
+  margin: 0 var(--size-2-1) 0 var(--size-4-1);
 }
 
 .smtcmp-chat-user-input-file-badge-name {

--- a/styles.css
+++ b/styles.css
@@ -337,12 +337,12 @@ button:not(.clickable-icon).smtcmp-chat-list-dropdown {
 }
 
 .smtcmp-chat-user-input-file-content-preview {
-  background-color: var(--background-primary);
+  background-color: var(--background-secondary);
   border-radius: var(--radius-s);
   border: 1px solid var(--background-modifier-border);
   max-height: 350px;
   overflow-y: auto;
-  white-space: pre-line;
+  padding: 0 var(--size-4-2);
 
   img {
     max-width: 100%;

--- a/styles.css
+++ b/styles.css
@@ -301,6 +301,10 @@ button:not(.clickable-icon).smtcmp-chat-list-dropdown {
     text-decoration: line-through;
     font-style: italic;
   }
+
+  svg {
+    flex-shrink: 0;
+  }
 }
 
 .smtcmp-chat-user-input-file-badge:hover {


### PR DESCRIPTION
## Description

This PR adds a new feature that allows users to toggle whether the current file's content should be included in the prompt when generating AI responses. The changes include:
- Added `includeCurrentFileContent` boolean to settings schema
- Added a toggle button (eye icon) to the current file badge
- Replaced the syntax highlighter with ObsidianMarkdown component in mentionable content preview

**Current file included**
![image](https://github.com/user-attachments/assets/d99faf55-a2ab-4bb5-99f3-def0eb09d3da)

**Current file excluded**
![image](https://github.com/user-attachments/assets/05b9e65d-2bd3-4c7d-87bb-b61391190507)

## Checklist before requesting a review
- [x] I have reviewed the [guidelines for contributing](../CONTRIBUTING.md) to this repository.
- [x] I have performed a self-review of my code
- [x] I have performed a code linting check and type check (by running `npm run lint:check` and `npm run type:check`)
- [x] I have run the test suite (by running `npm run test`)
- [x] I have tested the functionality manually


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a toggle to include or exclude the current file’s content when composing chat messages, accessible via an eye icon on the file badge.
- **Improvements**
  - File content in chat now displays with enhanced markdown rendering for better readability.
  - Visual indicators now show when file content is excluded, with updated icons and styling for clarity.
- **Style**
  - Refined file badge and content preview appearance, including updated icons, cursor changes, and improved layout.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->