### PR TITLE
feat: Add Mistral provider support

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -116,6 +116,14 @@ export const PROVIDER_TYPES_INFO = {
     supportEmbedding: false,
     additionalSettings: [],
   },
+  mistral: {
+    label: 'Mistral',
+    defaultProviderId: 'mistral',
+    requireApiKey: true,
+    requireBaseUrl: false,
+    supportEmbedding: false,
+    additionalSettings: [],
+  },
   morph: {
     label: 'Morph',
     defaultProviderId: 'morph',
@@ -212,6 +220,10 @@ export const DEFAULT_PROVIDERS: readonly LLMProvider[] = [
   {
     type: 'groq',
     id: PROVIDER_TYPES_INFO.groq.defaultProviderId,
+  },
+  {
+    type: 'mistral',
+    id: PROVIDER_TYPES_INFO.mistral.defaultProviderId,
   },
   {
     type: 'openrouter',

--- a/src/core/llm/manager.ts
+++ b/src/core/llm/manager.ts
@@ -9,6 +9,7 @@ import { DeepSeekStudioProvider } from './deepseekStudioProvider'
 import { GeminiProvider } from './gemini'
 import { GroqProvider } from './groq'
 import { LmStudioProvider } from './lmStudioProvider'
+import { MistralProvider } from './mistralProvider'
 import { MorphProvider } from './morphProvider'
 import { OllamaProvider } from './ollama'
 import { OpenAIAuthenticatedProvider } from './openai'
@@ -61,6 +62,9 @@ export function getProviderClient({
     }
     case 'perplexity': {
       return new PerplexityProvider(provider)
+    }
+    case 'mistral': {
+      return new MistralProvider(provider)
     }
     case 'morph': {
       return new MorphProvider(provider)

--- a/src/core/llm/mistralMessageAdapter.ts
+++ b/src/core/llm/mistralMessageAdapter.ts
@@ -1,0 +1,55 @@
+import { ChatCompletionCreateParamsNonStreaming } from 'openai/resources'
+import { ChatCompletionCreateParamsStreaming } from 'openai/resources/chat/completions'
+
+import { LLMRequest } from '../../types/llm/request'
+
+import { OpenAIMessageAdapter } from './openaiMessageAdapter'
+
+/**
+ * Mistral's API is not compatible with the `stream_options` parameter.
+ * This adapter overrides the default behavior to exclude `stream_options`
+ * from streaming requests, preventing errors when using Mistral models.
+ */
+export class MistralMessageAdapter extends OpenAIMessageAdapter {
+  protected override buildChatCompletionCreateParams(params: {
+    request: LLMRequest
+    stream: true
+  }): ChatCompletionCreateParamsStreaming
+  protected override buildChatCompletionCreateParams(params: {
+    request: LLMRequest
+    stream: false
+  }): ChatCompletionCreateParamsNonStreaming
+  protected override buildChatCompletionCreateParams({
+    request,
+    stream,
+  }: {
+    request: LLMRequest
+    stream: boolean
+  }):
+    | ChatCompletionCreateParamsStreaming
+    | ChatCompletionCreateParamsNonStreaming {
+    return {
+      model: request.model,
+      tools: request.tools,
+      tool_choice: request.tool_choice,
+      reasoning_effort: request.reasoning_effort,
+      web_search_options: request.web_search_options,
+      messages: request.messages.map((m) => this.parseRequestMessage(m)),
+      // TODO: max_tokens is deprecated in the OpenAI API, with max_completion_tokens being the
+      // recommended replacement. Reasoning models do not support max_tokens at all.
+      // However, many OpenAI-compatible APIs still only support max_tokens.
+      // Consider implementing a solution that works with both OpenAI and compatible APIs.
+      max_tokens: request.max_tokens,
+      temperature: request.temperature,
+      top_p: request.top_p,
+      frequency_penalty: request.frequency_penalty,
+      presence_penalty: request.presence_penalty,
+      logit_bias: request.logit_bias,
+      prediction: request.prediction,
+      ...(stream && {
+        stream: true,
+        // Omit stream_options for Mistral to prevent API errors.
+      }),
+    }
+  }
+}

--- a/src/core/llm/mistralProvider.ts
+++ b/src/core/llm/mistralProvider.ts
@@ -1,0 +1,64 @@
+import { ChatModel } from '../../types/chat-model.types'
+import {
+  LLMOptions,
+  LLMRequestNonStreaming,
+  LLMRequestStreaming,
+} from '../../types/llm/request'
+import {
+  LLMResponseNonStreaming,
+  LLMResponseStreaming,
+} from '../../types/llm/response'
+import { LLMProvider } from '../../types/provider.types'
+
+import { BaseLLMProvider } from './base'
+import { MistralMessageAdapter } from './mistralMessageAdapter'
+import { NoStainlessOpenAI } from './NoStainlessOpenAI'
+
+export class MistralProvider extends BaseLLMProvider<
+  Extract<LLMProvider, { type: 'mistral' }>
+> {
+  private adapter: MistralMessageAdapter
+  private client: NoStainlessOpenAI
+
+  constructor(provider: Extract<LLMProvider, { type: 'mistral' }>) {
+    super(provider)
+    this.adapter = new MistralMessageAdapter()
+    this.client = new NoStainlessOpenAI({
+      apiKey: provider.apiKey ?? '',
+      baseURL: provider.baseUrl
+        ? provider.baseUrl.replace(/\/+$/, '')
+        : 'https://api.mistral.ai/v1',
+      dangerouslyAllowBrowser: true,
+    })
+  }
+
+  async generateResponse(
+    model: ChatModel,
+    request: LLMRequestNonStreaming,
+    options?: LLMOptions,
+  ): Promise<LLMResponseNonStreaming> {
+    if (model.providerType !== 'mistral') {
+      throw new Error('Model is not a Mistral model')
+    }
+
+    return this.adapter.generateResponse(this.client, request, options)
+  }
+
+  async streamResponse(
+    model: ChatModel,
+    request: LLMRequestStreaming,
+    options?: LLMOptions,
+  ): Promise<AsyncIterable<LLMResponseStreaming>> {
+    if (model.providerType !== 'mistral') {
+      throw new Error('Model is not a Mistral model')
+    }
+
+    return this.adapter.streamResponse(this.client, request, options)
+  }
+
+  async getEmbedding(_model: string, _text: string): Promise<number[]> {
+    throw new Error(
+      `Provider ${this.provider.id} does not support embeddings. Please use a different provider.`,
+    )
+  }
+}

--- a/src/settings/schema/migrations/9_to_10.test.ts
+++ b/src/settings/schema/migrations/9_to_10.test.ts
@@ -1,0 +1,131 @@
+import { DEFAULT_PROVIDERS_V10, migrateFrom9To10 } from './9_to_10'
+
+describe('Migration from v9 to v10', () => {
+  it('should use default providers if providers is not present', () => {
+    const oldSettings = {
+      version: 9,
+    }
+    const result = migrateFrom9To10(oldSettings)
+    expect(result.version).toBe(10)
+    expect(result.providers).toEqual(DEFAULT_PROVIDERS_V10)
+  })
+
+  it('should merge existing providers and add new default provider (mistral)', () => {
+    const oldSettings = {
+      version: 9,
+      providers: [
+        { type: 'openai', id: 'openai', apiKey: 'openai-key' },
+        { type: 'anthropic', id: 'anthropic', apiKey: 'anthropic-key' },
+        { type: 'gemini', id: 'gemini', apiKey: 'gemini-key' },
+        { type: 'groq', id: 'groq', apiKey: 'groq-key' },
+        { type: 'deepseek', id: 'deepseek', apiKey: 'deepseek-key' },
+      ],
+    }
+    const result = migrateFrom9To10(oldSettings)
+    expect(result.version).toBe(10)
+    expect(result.providers).toEqual([
+      { type: 'openai', id: 'openai', apiKey: 'openai-key' },
+      { type: 'anthropic', id: 'anthropic', apiKey: 'anthropic-key' },
+      { type: 'gemini', id: 'gemini', apiKey: 'gemini-key' },
+      { type: 'deepseek', id: 'deepseek', apiKey: 'deepseek-key' },
+      { type: 'perplexity', id: 'perplexity' },
+      { type: 'groq', id: 'groq', apiKey: 'groq-key' },
+      { type: 'mistral', id: 'mistral' },
+      { type: 'openrouter', id: 'openrouter' },
+      { type: 'ollama', id: 'ollama' },
+      { type: 'lm-studio', id: 'lm-studio' },
+      { type: 'morph', id: 'morph' },
+    ])
+  })
+
+  it('should add default providers and preserve custom providers', () => {
+    const oldSettings = {
+      version: 9,
+      providers: [
+        ...DEFAULT_PROVIDERS_V10.filter((p) => p.id !== 'mistral'),
+        {
+          type: 'openai-compatible',
+          id: 'cohere',
+          baseUrl: 'https://api.cohere.ai',
+          apiKey: 'cohere-api-key',
+          additionalSettings: { noStainless: true },
+        },
+      ],
+    }
+    const result = migrateFrom9To10(oldSettings)
+    expect(result.version).toBe(10)
+    expect(result.providers).toEqual([
+      ...DEFAULT_PROVIDERS_V10,
+      {
+        type: 'openai-compatible',
+        id: 'cohere',
+        baseUrl: 'https://api.cohere.ai',
+        apiKey: 'cohere-api-key',
+        additionalSettings: { noStainless: true },
+      },
+    ])
+  })
+
+  it('should preserve custom fields on existing default providers', () => {
+    const oldSettings = {
+      version: 9,
+      providers: [
+        {
+          type: 'openai',
+          id: 'openai',
+          apiKey: 'openai-key',
+          customField: 'foo',
+        },
+        {
+          type: 'mistral',
+          id: 'mistral',
+          apiKey: 'mistral-key',
+          customField: 'bar',
+        },
+      ],
+    }
+    const result = migrateFrom9To10(oldSettings)
+    expect(result.version).toBe(10)
+    expect(result.providers).toEqual([
+      {
+        type: 'openai',
+        id: 'openai',
+        apiKey: 'openai-key',
+        customField: 'foo',
+      },
+      { type: 'anthropic', id: 'anthropic' },
+      { type: 'gemini', id: 'gemini' },
+      { type: 'deepseek', id: 'deepseek' },
+      { type: 'perplexity', id: 'perplexity' },
+      { type: 'groq', id: 'groq' },
+      {
+        type: 'mistral',
+        id: 'mistral',
+        apiKey: 'mistral-key',
+        customField: 'bar',
+      },
+      { type: 'openrouter', id: 'openrouter' },
+      { type: 'ollama', id: 'ollama' },
+      { type: 'lm-studio', id: 'lm-studio' },
+      { type: 'morph', id: 'morph' },
+    ])
+  })
+
+  it('should handle a custom provider with id "mistral" and type "openai-compatible"', () => {
+    const oldSettings = {
+      version: 9,
+      providers: [
+        {
+          type: 'openai-compatible',
+          id: 'mistral',
+          baseUrl: 'https://custom-mistral-endpoint',
+          apiKey: 'custom-mistral-key',
+          customField: 'custom',
+        },
+      ],
+    }
+    const result = migrateFrom9To10(oldSettings)
+    expect(result.version).toBe(10)
+    expect(result.providers).toEqual(DEFAULT_PROVIDERS_V10)
+  })
+})

--- a/src/settings/schema/migrations/9_to_10.ts
+++ b/src/settings/schema/migrations/9_to_10.ts
@@ -1,0 +1,61 @@
+import { SettingMigration } from '../setting.types'
+
+import { DefaultProviders, getMigratedProviders } from './migrationUtils'
+
+/**
+ * Migration from version 9 to version 10
+ * - Add mistral provider
+ */
+export const DEFAULT_PROVIDERS_V10: DefaultProviders = [
+  {
+    type: 'openai',
+    id: 'openai',
+  },
+  {
+    type: 'anthropic',
+    id: 'anthropic',
+  },
+  {
+    type: 'gemini',
+    id: 'gemini',
+  },
+  {
+    type: 'deepseek',
+    id: 'deepseek',
+  },
+  {
+    type: 'perplexity',
+    id: 'perplexity',
+  },
+  {
+    type: 'groq',
+    id: 'groq',
+  },
+  {
+    type: 'mistral',
+    id: 'mistral',
+  },
+  {
+    type: 'openrouter',
+    id: 'openrouter',
+  },
+  {
+    type: 'ollama',
+    id: 'ollama',
+  },
+  {
+    type: 'lm-studio',
+    id: 'lm-studio',
+  },
+  {
+    type: 'morph',
+    id: 'morph',
+  },
+]
+
+export const migrateFrom9To10: SettingMigration['migrate'] = (data) => {
+  const newData = { ...data }
+  newData.version = 10
+  newData.providers = getMigratedProviders(newData, DEFAULT_PROVIDERS_V10)
+  return newData
+}

--- a/src/settings/schema/migrations/index.ts
+++ b/src/settings/schema/migrations/index.ts
@@ -9,8 +9,9 @@ import { migrateFrom5To6 } from './5_to_6'
 import { migrateFrom6To7 } from './6_to_7'
 import { migrateFrom7To8 } from './7_to_8'
 import { migrateFrom8To9 } from './8_to_9'
+import { migrateFrom9To10 } from './9_to_10'
 
-export const SETTINGS_SCHEMA_VERSION = 9
+export const SETTINGS_SCHEMA_VERSION = 10
 
 export const SETTING_MIGRATIONS: SettingMigration[] = [
   {
@@ -57,5 +58,10 @@ export const SETTING_MIGRATIONS: SettingMigration[] = [
     fromVersion: 8,
     toVersion: 9,
     migrate: migrateFrom8To9,
+  },
+  {
+    fromVersion: 9,
+    toVersion: 10,
+    migrate: migrateFrom9To10,
   },
 ]

--- a/src/types/chat-model.types.ts
+++ b/src/types/chat-model.types.ts
@@ -74,6 +74,10 @@ export const chatModelSchema = z.discriminatedUnion('providerType', [
       .optional(),
   }),
   z.object({
+    providerType: z.literal('mistral'),
+    ...baseChatModelSchema.shape,
+  }),
+  z.object({
     providerType: z.literal('morph'),
     ...baseChatModelSchema.shape,
   }),

--- a/src/types/embedding-model.types.ts
+++ b/src/types/embedding-model.types.ts
@@ -57,6 +57,10 @@ export const embeddingModelSchema = z.discriminatedUnion('providerType', [
     ...baseEmbeddingModelSchema.shape,
   }),
   z.object({
+    providerType: z.literal('mistral'),
+    ...baseEmbeddingModelSchema.shape,
+  }),
+  z.object({
     providerType: z.literal('morph'),
     ...baseEmbeddingModelSchema.shape,
   }),

--- a/src/types/provider.types.ts
+++ b/src/types/provider.types.ts
@@ -40,6 +40,10 @@ export const llmProviderSchema = z.discriminatedUnion('type', [
     ...baseLlmProviderSchema.shape,
   }),
   z.object({
+    type: z.literal('mistral'),
+    ...baseLlmProviderSchema.shape,
+  }),
+  z.object({
     type: z.literal('openrouter'),
     ...baseLlmProviderSchema.shape,
   }),


### PR DESCRIPTION
## Description

- Introduced `MistralProvider` and `MistralMessageAdapter` for Mistral API integration.
- Updated settings schema version to 10.
- Refactored `OpenAIMessageAdapter`: Extracted request parameter construction into a dedicated method (`buildChatCompletionCreateParams`) to improve extensibility and enable provider-specific overrides.

## Related Issue
- Resolves #273 

## Checklist before requesting a review
- [x] I have reviewed the [guidelines for contributing](../CONTRIBUTING.md) to this repository.
- [x] I have performed a self-review of my code
- [x] I have performed a code linting check and type check (by running `npm run lint:check` and `npm run type:check`)
- [x] I have run the test suite (by running `npm run test`)
- [x] I have tested the functionality manually


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for the Mistral language model provider, allowing users to select and interact with Mistral models for chat completions.
- **Bug Fixes**
  - Prevented errors when using streaming with Mistral by ensuring unsupported streaming options are not sent to the API.
- **Migration**
  - Updated settings to automatically include Mistral as a default provider during migration to the latest version.
- **Tests**
  - Added tests to verify correct migration and provider merging, ensuring custom and default providers are handled properly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->