### PR TITLE
Remove "non-verbose" instruction

### DIFF
--- a/src/utils/chat/promptGenerator.ts
+++ b/src/utils/chat/promptGenerator.ts
@@ -414,22 +414,20 @@ ${await this.getWebsiteContent(url)}
     const modelPromptLevel = this.getModelPromptLevel()
     const systemPrompt = `You are an intelligent assistant to help answer any questions that the user has${modelPromptLevel == PromptLevel.Default ? `, particularly about editing and organizing markdown files in Obsidian` : ''}.
 
-1. Please keep your response as concise as possible. Avoid being verbose.
+1. Do not lie or make up facts.
 
-2. Do not lie or make up facts.
-
-3. Format your response in markdown.
+2. Format your response in markdown.
 
 ${
   modelPromptLevel == PromptLevel.Default
-    ? `4. Respond in the same language as the user's message.
+    ? `3. Respond in the same language as the user's message.
 
-5. When writing out new markdown blocks, also wrap them with <smtcmp_block> tags. For example:
+4. When writing out new markdown blocks, also wrap them with <smtcmp_block> tags. For example:
 <smtcmp_block language="markdown">
 {{ content }}
 </smtcmp_block>
 
-6. When providing markdown blocks for an existing file, add the filename and language attributes to the <smtcmp_block> tags. Restate the relevant section or heading, so the user knows which part of the file you are editing. For example:
+5. When providing markdown blocks for an existing file, add the filename and language attributes to the <smtcmp_block> tags. Restate the relevant section or heading, so the user knows which part of the file you are editing. For example:
 <smtcmp_block filename="path/to/file.md" language="markdown">
 ## Section Title
 ...
@@ -437,7 +435,7 @@ ${
 ...
 </smtcmp_block>
 
-7. When the user is asking for edits to their markdown, please provide a simplified version of the markdown block emphasizing only the changes. Use comments to show where unchanged content has been skipped. Wrap the markdown block with <smtcmp_block> tags. Add filename and language attributes to the <smtcmp_block> tags. For example:
+6. When the user is asking for edits to their markdown, please provide a simplified version of the markdown block emphasizing only the changes. Use comments to show where unchanged content has been skipped. Wrap the markdown block with <smtcmp_block> tags. Add filename and language attributes to the <smtcmp_block> tags. For example:
 <smtcmp_block filename="path/to/file.md" language="markdown">
 <!-- ... existing content ... -->
 {{ edit_1 }}


### PR DESCRIPTION
## Description

It is extremely hard to make Smart Composer verbose: https://github.com/glowingjade/obsidian-smart-composer/issues/394

For vault chats, there is not the instruction to avoid to be verbose. I think we should also remove it for regular chats. If a user wants it not to be verbose, he could add the instruction himself (or add in the system prompt setting).

Closes https://github.com/glowingjade/obsidian-smart-composer/issues/394

## Checklist before requesting a review
- [x] I have reviewed the [guidelines for contributing](../CONTRIBUTING.md) to this repository.
- [x] I have performed a self-review of my code
- [x] I have performed a code linting check and type check (by running `npm run lint:check` and `npm run type:check`)
- [x] I have run the test suite (by running `npm run test`)
- [x] I have tested the functionality manually


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Updated the system prompt by removing the initial instruction about conciseness and adjusted the numbering of the remaining instructions for clarity. No changes to visible features or functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->