### PR TITLE
Fix: Handle undefined arguments in REST API calls with no parameter

### DIFF
--- a/src/core/mcp/mcpManager.ts
+++ b/src/core/mcp/mcpManager.ts
@@ -393,7 +393,7 @@ export class McpManager {
       const result = (await client.callTool(
         {
           name: toolName,
-          arguments: parsedArgs,
+          arguments: parsedArgs ?? {},
         },
         undefined,
         {


### PR DESCRIPTION
### Overview
This pull request addresses an issue where REST API calls without parameters would fail due to `arguments` being undefined.

### Changes
- Added a fallback mechanism to handle cases where `arguments` is not defined in REST API calls.