### PR TITLE
Update Gemini 2.5 Pro Model Name and Add Migration to Schema v11

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -329,6 +329,12 @@ export const DEFAULT_CHAT_MODELS: readonly ChatModel[] = [
   {
     providerType: 'gemini',
     providerId: PROVIDER_TYPES_INFO.gemini.defaultProviderId,
+    id: 'gemini-2.5-flash',
+    model: 'gemini-2.5-flash',
+  },
+  {
+    providerType: 'gemini',
+    providerId: PROVIDER_TYPES_INFO.gemini.defaultProviderId,
     id: 'gemini-2.0-flash',
     model: 'gemini-2.0-flash',
   },

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -324,7 +324,7 @@ export const DEFAULT_CHAT_MODELS: readonly ChatModel[] = [
     providerType: 'gemini',
     providerId: PROVIDER_TYPES_INFO.gemini.defaultProviderId,
     id: 'gemini-2.5-pro',
-    model: 'gemini-2.5-pro-exp-03-25',
+    model: 'gemini-2.5-pro',
   },
   {
     providerType: 'gemini',

--- a/src/settings/schema/migrations/10_to_11.test.ts
+++ b/src/settings/schema/migrations/10_to_11.test.ts
@@ -1,0 +1,117 @@
+import { migrateFrom10To11 } from './10_to_11'
+
+type SettingsData = {
+  version: number
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  chatModels?: any[]
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  [key: string]: any
+}
+
+describe('migrateFrom10To11', () => {
+  it('should update the gemini-2.5-pro model name', () => {
+    const mockData: SettingsData = {
+      version: 10,
+      chatModels: [
+        {
+          providerType: 'gemini',
+          providerId: 'gemini',
+          id: 'gemini-2.5-pro',
+          model: 'gemini-2.5-pro-preview-03-25',
+        },
+        {
+          providerType: 'gemini',
+          providerId: 'gemini',
+          id: 'gemini-1.5-pro',
+          model: 'gemini-1.5-pro',
+        },
+      ],
+    }
+
+    const migratedData = migrateFrom10To11(mockData) as SettingsData
+
+    // Check if version is updated
+    expect(migratedData.version).toBe(11)
+
+    // Check if the gemini-2.5-pro model name is updated
+    const gemini25Pro = migratedData.chatModels?.find(
+      (model) => model.id === 'gemini-2.5-pro',
+    )
+    expect(gemini25Pro).toBeDefined()
+    expect(gemini25Pro?.model).toBe('gemini-2.5-pro')
+
+    // Check if other models remain unchanged
+    const gemini15Pro = migratedData.chatModels?.find(
+      (model) => model.id === 'gemini-1.5-pro',
+    )
+    expect(gemini15Pro).toBeDefined()
+    expect(gemini15Pro?.model).toBe('gemini-1.5-pro')
+  })
+
+  it('should handle empty or non-existent chatModels', () => {
+    const mockDataEmpty: SettingsData = {
+      version: 10,
+      chatModels: [],
+    }
+
+    const mockDataNoModels: SettingsData = {
+      version: 8,
+    }
+
+    const migratedDataEmpty = migrateFrom10To11(mockDataEmpty) as SettingsData
+    const migratedDataNoModels = migrateFrom10To11(
+      mockDataNoModels,
+    ) as SettingsData
+
+    // Check if version is updated
+    expect(migratedDataEmpty.version).toBe(11)
+    expect(migratedDataNoModels.version).toBe(11)
+
+    // Check if chatModels is defined and contains the default models
+    expect(migratedDataEmpty.chatModels).toBeDefined()
+    expect(migratedDataNoModels.chatModels).toBeDefined()
+
+    // Verify the gemini-2.5-pro model has the correct name
+    const gemini25ProEmpty = migratedDataEmpty.chatModels?.find(
+      (model) => model.id === 'gemini-2.5-pro',
+    )
+    const gemini25ProNoModels = migratedDataNoModels.chatModels?.find(
+      (model) => model.id === 'gemini-2.5-pro',
+    )
+
+    expect(gemini25ProEmpty).toBeDefined()
+    expect(gemini25ProEmpty?.model).toBe('gemini-2.5-pro')
+    expect(gemini25ProNoModels).toBeDefined()
+    expect(gemini25ProNoModels?.model).toBe('gemini-2.5-pro')
+  })
+
+  it('should preserve custom chat models', () => {
+    const mockData: SettingsData = {
+      version: 10,
+      chatModels: [
+        {
+          providerType: 'gemini',
+          providerId: 'gemini',
+          id: 'gemini-2.5-pro',
+          model: 'gemini-2.5-pro-exp-03-25',
+        },
+        {
+          providerType: 'custom',
+          providerId: 'custom-provider',
+          id: 'custom-model',
+          model: 'custom-model-name',
+        },
+      ],
+    }
+
+    const migratedData = migrateFrom10To11(mockData) as SettingsData
+
+    // Check if custom model is preserved
+    const customModel = migratedData.chatModels?.find(
+      (model) => model.id === 'custom-model',
+    )
+    expect(customModel).toBeDefined()
+    expect(customModel?.model).toBe('custom-model-name')
+    expect(customModel?.providerType).toBe('custom')
+  })
+})

--- a/src/settings/schema/migrations/10_to_11.ts
+++ b/src/settings/schema/migrations/10_to_11.ts
@@ -1,0 +1,24 @@
+import { SettingMigration } from '../setting.types'
+
+import { DEFAULT_CHAT_MODELS_V9 } from './8_to_9'
+import { DefaultChatModels, getMigratedChatModels } from './migrationUtils'
+
+/**
+ * Migration from version 10 to version 11
+ * - Update the Gemini 2.5 Pro model from gemini-2.5-pro-preview-03-25 to gemini-2.5-pro
+ */
+
+export const DEFAULT_CHAT_MODELS_V11: DefaultChatModels =
+  DEFAULT_CHAT_MODELS_V9.map((model) => {
+    if (model.id === 'gemini-2.5-pro') {
+      return { ...model, model: 'gemini-2.5-pro' }
+    }
+    return model
+  })
+
+export const migrateFrom10To11: SettingMigration['migrate'] = (data) => {
+  const newData = { ...data }
+  newData.version = 11
+  newData.chatModels = getMigratedChatModels(newData, DEFAULT_CHAT_MODELS_V11)
+  return newData
+}

--- a/src/settings/schema/migrations/index.ts
+++ b/src/settings/schema/migrations/index.ts
@@ -1,6 +1,7 @@
 import { SettingMigration } from '../setting.types'
 
 import { migrateFrom0To1 } from './0_to_1'
+import { migrateFrom10To11 } from './10_to_11'
 import { migrateFrom1To2 } from './1_to_2'
 import { migrateFrom2To3 } from './2_to_3'
 import { migrateFrom3To4 } from './3_to_4'
@@ -11,7 +12,7 @@ import { migrateFrom7To8 } from './7_to_8'
 import { migrateFrom8To9 } from './8_to_9'
 import { migrateFrom9To10 } from './9_to_10'
 
-export const SETTINGS_SCHEMA_VERSION = 10
+export const SETTINGS_SCHEMA_VERSION = 11
 
 export const SETTING_MIGRATIONS: SettingMigration[] = [
   {
@@ -63,5 +64,10 @@ export const SETTING_MIGRATIONS: SettingMigration[] = [
     fromVersion: 9,
     toVersion: 10,
     migrate: migrateFrom9To10,
+  },
+  {
+    fromVersion: 10,
+    toVersion: 11,
+    migrate: migrateFrom10To11,
   },
 ]


### PR DESCRIPTION
## Description

Since gemini-2.5-pro has been officially released, the model name is migrated from gemini-2.5-pro-exp-03-25 to gemini-2.5-pro.  
For more details, please refer to the official documentation: https://ai.google.dev/gemini-api/docs/models#model-variations

## Checklist before requesting a review
- [x] I have reviewed the [guidelines for contributing](../CONTRIBUTING.md) to this repository.
- [x] I have performed a self-review of my code
- [x] I have performed a code linting check and type check (by running `npm run lint:check` and `npm run type:check`)
- [x] I have run the test suite (by running `npm run test`)
- [x] I have tested the functionality manually
