### PR TITLE
Added system prompt switching functionality to the chat interface via a dropdown menu.

### DIFF
--- a/src/components/chat-view/chat-input/LexicalContentEditable.tsx
+++ b/src/components/chat-view/chat-input/LexicalContentEditable.tsx
@@ -28,6 +28,7 @@ import OnMutationPlugin, {
 } from './plugins/on-mutation/OnMutationPlugin'
 import CreateTemplatePopoverPlugin from './plugins/template/CreateTemplatePopoverPlugin'
 import TemplatePlugin from './plugins/template/TemplatePlugin'
+import { BaseSerializedNode } from '@lexical/clipboard/clipboard'
 
 export type LexicalContentEditableProps = {
   editorRef: RefObject<LexicalEditor>
@@ -45,6 +46,7 @@ export type LexicalContentEditableProps = {
     }
     templatePopover?: {
       anchorElement: HTMLElement | null
+      onOpenCreateDialog: (selectedSerializedNodes: BaseSerializedNode[] | null) => void
     }
   }
 }
@@ -146,6 +148,7 @@ export default function LexicalContentEditable({
         <CreateTemplatePopoverPlugin
           anchorElement={plugins.templatePopover.anchorElement}
           contentEditableElement={contentEditableRef.current}
+          onOpenCreateDialog={plugins.templatePopover.onOpenCreateDialog}
         />
       )}
     </LexicalComposer>

--- a/src/components/chat-view/chat-input/plugins/template/CreateTemplatePopoverPlugin.tsx
+++ b/src/components/chat-view/chat-input/plugins/template/CreateTemplatePopoverPlugin.tsx
@@ -1,7 +1,6 @@
 import { $generateJSONFromSelectedNodes } from '@lexical/clipboard'
 import { BaseSerializedNode } from '@lexical/clipboard/clipboard'
 import { useLexicalComposerContext } from '@lexical/react/LexicalComposerContext'
-import * as Dialog from '@radix-ui/react-dialog'
 import {
   $getSelection,
   COMMAND_PRIORITY_LOW,
@@ -9,23 +8,19 @@ import {
 } from 'lexical'
 import { CSSProperties, useCallback, useEffect, useRef, useState } from 'react'
 
-import CreateTemplateDialogContent from '../../../CreateTemplateDialog'
-
 export default function CreateTemplatePopoverPlugin({
   anchorElement,
   contentEditableElement,
+  onOpenCreateDialog,
 }: {
   anchorElement: HTMLElement | null
   contentEditableElement: HTMLElement | null
+  onOpenCreateDialog: (selectedSerializedNodes: BaseSerializedNode[] | null) => void
 }): JSX.Element | null {
   const [editor] = useLexicalComposerContext()
 
   const [popoverStyle, setPopoverStyle] = useState<CSSProperties | null>(null)
   const [isPopoverOpen, setIsPopoverOpen] = useState(false)
-  const [isDialogOpen, setIsDialogOpen] = useState(false)
-  const [selectedSerializedNodes, setSelectedSerializedNodes] = useState<
-    BaseSerializedNode[] | null
-  >(null)
 
   const popoverRef = useRef<HTMLButtonElement>(null)
 
@@ -114,33 +109,20 @@ export default function CreateTemplatePopoverPlugin({
   }, [contentEditableElement, updatePopoverPosition])
 
   return (
-    <Dialog.Root
-      modal={false}
-      open={isDialogOpen}
-      onOpenChange={(open) => {
-        if (open) {
-          setSelectedSerializedNodes(getSelectedSerializedNodes())
-        }
-        setIsDialogOpen(open)
+    <button
+      ref={popoverRef}
+      style={{
+        position: 'absolute',
+        visibility: isPopoverOpen ? 'visible' : 'hidden',
+        ...popoverStyle,
+      }}
+      onClick={() => {
+        const selectedNodes = getSelectedSerializedNodes()
+        onOpenCreateDialog(selectedNodes)
         setIsPopoverOpen(false)
       }}
     >
-      <Dialog.Trigger asChild>
-        <button
-          ref={popoverRef}
-          style={{
-            position: 'absolute',
-            visibility: isPopoverOpen ? 'visible' : 'hidden',
-            ...popoverStyle,
-          }}
-        >
-          Create template
-        </button>
-      </Dialog.Trigger>
-      <CreateTemplateDialogContent
-        selectedSerializedNodes={selectedSerializedNodes}
-        onClose={() => setIsDialogOpen(false)}
-      />
-    </Dialog.Root>
+      Create template
+    </button>
   )
 }

--- a/styles.css
+++ b/styles.css
@@ -908,7 +908,7 @@ button.smtcmp-chat-input-template-select {
   position: fixed;
   left: calc(50% - var(--size-4-4));
   top: 50%;
-  z-index: 50;
+  z-index: 1001;
   display: grid;
   width: calc(100% - var(--size-4-8));
   max-width: 32rem;


### PR DESCRIPTION
## 描述
因为我没有任何编程基础，所以这些更改都是尽量利用现有功能实现的。
1. 在模型选择菜单旁边添加一个下拉式菜单，菜单可以调用现有的自定义提示词模板。
2. 在下拉式菜单中选择某一个提示词之后，会将选中的提示词传递给系统提示词。
3. 在下拉式菜单中的模型名称后面添加一个编辑按钮，点击编辑按钮可以调用现有的创建提示词窗口。
4. 改动了创建提示词窗口的逻辑：如果输入的提示词名称与现有提示词重名，则会覆盖现有提示词；如果输入的提示词名称与现有提示词不重名，则会创建一个新的提示词。

## Description
Since I have no programming background, these changes are made by leveraging existing functionalities as much as possible.

1. Add a dropdown menu next to the model selection menu, which can call existing custom prompt templates.
2. After selecting a prompt from the dropdown menu, the selected prompt will be passed to the system prompt.
3. Add an edit button next to the model name in the dropdown menu. Clicking the edit button will invoke the existing prompt creation window.
4. Modified the logic of the prompt creation window: if the entered prompt name is the same as an existing prompt, it will overwrite the existing prompt; if the entered prompt name is different from any existing prompt, a new prompt will be created.

![image](https://github.com/user-attachments/assets/a22ea2da-d6a5-40aa-8106-86ce3ee87f54)
![image](https://github.com/user-attachments/assets/b5401892-9f95-4b66-a55d-12b84b3d26aa)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added the ability to edit existing templates in addition to creating new ones within the chat interface.
  - Introduced a dropdown menu for selecting, editing, and deleting system prompt templates.
  - Enhanced template management with options to update or create templates based on name.

- **Improvements**
  - Updated dialog UI to dynamically reflect create or edit mode.
  - Improved horizontal alignment and spacing of chat input controls.
  - Increased dialog stacking order for better visibility.

- **Bug Fixes**
  - Prevented accidental dialog closing by introducing a delayed close action.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->