### PR TITLE
Linked Mentions Iteration 2

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+# Auto detect text files and perform LF normalization
+* text=auto

--- a/src/components/chat-view/QueryProgress.tsx
+++ b/src/components/chat-view/QueryProgress.tsx
@@ -1,3 +1,5 @@
+// src/components/chat-view/QueryProgress.tsx
+
 import { SelectEmbedding } from '../../database/schema'
 import DotLoader from '../common/DotLoader'
 
@@ -17,6 +19,9 @@ export type QueryProgressState =
       queryResult: (Omit<SelectEmbedding, 'embedding'> & {
         similarity: number
       })[]
+    }
+  | {
+      type: 'fetching-links' // New state
     }
   | {
       type: 'idle'
@@ -84,6 +89,15 @@ export default function QueryProgress({
               <p>{result.similarity}</p>
             </div>
           ))}
+        </div>
+      )
+    case 'fetching-links': // New case
+      return (
+        <div className="smtcmp-query-progress">
+          <p>
+            Fetching linked notes
+            <DotLoader />
+          </p>
         </div>
       )
   }

--- a/src/components/chat-view/UserMessageItem.tsx
+++ b/src/components/chat-view/UserMessageItem.tsx
@@ -1,3 +1,5 @@
+// src/components/chat-view/chat-input/UserMessageItem.tsx
+
 import { SerializedEditorState } from 'lexical'
 
 import { ChatUserMessage } from '../../types/chat'
@@ -13,6 +15,7 @@ export type UserMessageItemProps = {
   onSubmit: (content: SerializedEditorState, useVaultSearch: boolean) => void
   onFocus: () => void
   onMentionablesChange: (mentionables: Mentionable[]) => void
+  onDepthChange: (mentionableKey: string, forward: number, backward: number) => void;
 }
 
 export default function UserMessageItem({
@@ -22,6 +25,7 @@ export default function UserMessageItem({
   onSubmit,
   onFocus,
   onMentionablesChange,
+  onDepthChange,
 }: UserMessageItemProps) {
   return (
     <div className="smtcmp-chat-messages-user">
@@ -33,6 +37,7 @@ export default function UserMessageItem({
         onFocus={onFocus}
         mentionables={message.mentionables}
         setMentionables={onMentionablesChange}
+        onDepthChange={onDepthChange}
       />
       {message.similaritySearchResults && (
         <SimilaritySearchResults

--- a/src/components/chat-view/chat-input/ChatUserInput.tsx
+++ b/src/components/chat-view/chat-input/ChatUserInput.tsx
@@ -1,3 +1,5 @@
+// src/components/chat-view/chat-input/ChatUserInput.tsx
+
 import { useQuery } from '@tanstack/react-query'
 import { $nodesOfType, LexicalEditor, SerializedEditorState } from 'lexical'
 import {
@@ -46,6 +48,7 @@ export type ChatUserInputProps = {
   onFocus: () => void
   mentionables: Mentionable[]
   setMentionables: (mentionables: Mentionable[]) => void
+  onDepthChange: (mentionableKey: string, forward: number, backward: number) => void;
   autoFocus?: boolean
   addedBlockKey?: string | null
 }
@@ -59,6 +62,7 @@ const ChatUserInput = forwardRef<ChatUserInputRef, ChatUserInputProps>(
       onFocus,
       mentionables,
       setMentionables,
+      onDepthChange,
       autoFocus = false,
       addedBlockKey,
     },
@@ -220,7 +224,6 @@ const ChatUserInput = forwardRef<ChatUserInputRef, ChatUserInputProps>(
                   m.file &&
                   mentionableKey === displayedMentionableKey
                 ) {
-                  // open file on click again
                   openMarkdownFile(
                     app,
                     m.file.path,
@@ -234,6 +237,7 @@ const ChatUserInput = forwardRef<ChatUserInputRef, ChatUserInputProps>(
                 getMentionableKey(serializeMentionable(m)) ===
                 displayedMentionableKey
               }
+              onDepthChange={(f, b) => onDepthChange(getMentionableKey(serializeMentionable(m)), f, b)}
             />
           ))}
         </div>
@@ -316,7 +320,7 @@ function MentionableContentPreview({
     queryKey: [
       'file',
       displayedMentionableKey,
-      mentionables.map((m) => getMentionableKey(serializeMentionable(m))), // should be updated when mentionables change (especially on delete)
+      mentionables.map((m) => getMentionableKey(serializeMentionable(m))),
     ],
     queryFn: async () => {
       if (!displayedMentionable) return null

--- a/src/components/settings/sections/ChatSection.tsx
+++ b/src/components/settings/sections/ChatSection.tsx
@@ -1,3 +1,5 @@
+// src/components/settings/sections/ChatSection.tsx
+
 import {
   RECOMMENDED_MODELS_FOR_APPLY,
   RECOMMENDED_MODELS_FOR_CHAT,
@@ -11,6 +13,27 @@ import { ObsidianToggle } from '../../common/ObsidianToggle'
 
 export function ChatSection() {
   const { settings, setSettings } = useSettings()
+
+  const handleDepthChange = (
+    value: string,
+    field: 'forwardLinkDepth' | 'backwardLinkDepth' | 'activeFileForwardLinkDepth' | 'activeFileBackwardLinkDepth'
+  ) => {
+    const depth = parseInt(value, 10);
+    const inputEl = document.querySelector(`[data-field-name="${field}"]`) as HTMLInputElement;
+
+    if (!isNaN(depth) && depth >= 0 && depth <= 5) {
+      setSettings({
+        ...settings,
+        chatOptions: {
+          ...settings.chatOptions,
+          [field]: depth,
+        },
+      });
+      if (inputEl) inputEl.style.borderColor = 'var(--background-modifier-border)';
+    } else {
+      if (inputEl) inputEl.style.borderColor = 'var(--text-error)';
+    }
+  };
 
   return (
     <div className="smtcmp-settings-section">
@@ -98,6 +121,31 @@ export function ChatSection() {
         />
       </ObsidianSetting>
 
+      {settings.chatOptions.includeCurrentFileContent && (
+        <>
+          <ObsidianSetting
+            name="Active file forward link depth"
+            desc="Default forward link depth for the active file (0-5)."
+          >
+            <ObsidianTextInput
+              value={String(settings.chatOptions.activeFileForwardLinkDepth)}
+              onChange={(value) => handleDepthChange(value, 'activeFileForwardLinkDepth')}
+              inputAttrs={{ "data-field-name": "activeFileForwardLinkDepth" }}
+            />
+          </ObsidianSetting>
+          <ObsidianSetting
+            name="Active file backward link depth"
+            desc="Default backward link depth for the active file (0-5)."
+          >
+            <ObsidianTextInput
+              value={String(settings.chatOptions.activeFileBackwardLinkDepth)}
+              onChange={(value) => handleDepthChange(value, 'activeFileBackwardLinkDepth')}
+              inputAttrs={{ "data-field-name": "activeFileBackwardLinkDepth" }}
+            />
+          </ObsidianSetting>
+        </>
+      )}
+
       <ObsidianSetting
         name="Enable tools"
         desc="Allow the AI to use MCP tools."
@@ -137,6 +185,68 @@ export function ChatSection() {
           }}
         />
       </ObsidianSetting>
+
+      <ObsidianSetting
+        name="Enable forward links"
+        desc="Automatically include notes linked from your mentioned files."
+      >
+        <ObsidianToggle
+          value={settings.chatOptions.enableForwardLinks}
+          onChange={async (value) => {
+            await setSettings({
+              ...settings,
+              chatOptions: {
+                ...settings.chatOptions,
+                enableForwardLinks: value,
+              },
+            })
+          }}
+        />
+      </ObsidianSetting>
+      
+      {settings.chatOptions.enableForwardLinks && (
+          <ObsidianSetting
+            name="Forward link depth"
+            desc="How many links deep to follow forward links (0-5)."
+          >
+            <ObsidianTextInput
+              value={String(settings.chatOptions.forwardLinkDepth)}
+              onChange={(value) => handleDepthChange(value, 'forwardLinkDepth')}
+              inputAttrs={{ "data-field-name": "forwardLinkDepth" }}
+            />
+          </ObsidianSetting>
+      )}
+
+      <ObsidianSetting
+        name="Enable backward links"
+        desc="Automatically include notes that link to your mentioned files."
+      >
+        <ObsidianToggle
+          value={settings.chatOptions.enableBackwardLinks}
+          onChange={async (value) => {
+            await setSettings({
+              ...settings,
+              chatOptions: {
+                ...settings.chatOptions,
+                enableBackwardLinks: value,
+              },
+            })
+          }}
+        />
+      </ObsidianSetting>
+      
+      {settings.chatOptions.enableBackwardLinks && (
+          <ObsidianSetting
+            name="Backward link depth"
+            desc="How many links deep to follow backward links (0-5)."
+          >
+            <ObsidianTextInput
+              value={String(settings.chatOptions.backwardLinkDepth)}
+              onChange={(value) => handleDepthChange(value, 'backwardLinkDepth')}
+              inputAttrs={{ "data-field-name": "backwardLinkDepth" }}
+            />
+          </ObsidianSetting>
+      )}
     </div>
   )
 }

--- a/src/settings/schema/setting.types.ts
+++ b/src/settings/schema/setting.types.ts
@@ -1,3 +1,5 @@
+// src/settings/schema/setting.types.ts
+
 import { z } from 'zod'
 
 import {
@@ -74,11 +76,23 @@ export const smartComposerSettingsSchema = z.object({
       includeCurrentFileContent: z.boolean(),
       enableTools: z.boolean(),
       maxAutoIterations: z.number(),
+      enableForwardLinks: z.boolean().default(false),
+      forwardLinkDepth: z.number().min(0).max(5).default(0),
+      enableBackwardLinks: z.boolean().default(false),
+      backwardLinkDepth: z.number().min(0).max(5).default(0),
+      activeFileForwardLinkDepth: z.number().min(0).max(5).default(0),
+      activeFileBackwardLinkDepth: z.number().min(0).max(5).default(0),
     })
     .catch({
       includeCurrentFileContent: true,
       enableTools: true,
       maxAutoIterations: 1,
+      enableForwardLinks: false,
+      forwardLinkDepth: 0,
+      enableBackwardLinks: false,
+      backwardLinkDepth: 0,
+      activeFileForwardLinkDepth: 0,
+      activeFileBackwardLinkDepth: 0,
     }),
 })
 export type SmartComposerSettings = z.infer<typeof smartComposerSettingsSchema>

--- a/src/types/mentionable.ts
+++ b/src/types/mentionable.ts
@@ -1,8 +1,12 @@
+// src/types/mentionable.ts
+
 import { TFile, TFolder } from 'obsidian'
 
 export type MentionableFile = {
   type: 'file'
   file: TFile
+  forwardDepth?: number
+  backwardDepth?: number
 }
 export type MentionableFolder = {
   type: 'folder'
@@ -45,6 +49,8 @@ export type Mentionable =
 export type SerializedMentionableFile = {
   type: 'file'
   file: string
+  forwardDepth?: number
+  backwardDepth?: number
 }
 export type SerializedMentionableFolder = {
   type: 'folder'

--- a/src/utils/chat/commandParser.ts
+++ b/src/utils/chat/commandParser.ts
@@ -1,0 +1,43 @@
+// src/utils/chat/commandParser.ts
+
+export interface ParsedLinkDepth {
+    cleanName: string;
+    forward?: number;
+    backward?: number;
+}
+
+/**
+ * Parses a string like "FileName:f2:b1" into a structured object.
+ * @param input The string to parse.
+ * @returns A ParsedLinkDepth object.
+ */
+export function parseLinkDepthCommand(input: string): ParsedLinkDepth {
+    const result: ParsedLinkDepth = {
+        cleanName: input,
+    };
+
+    const parts = input.split(':');
+    if (parts.length === 1) {
+        return result;
+    }
+
+    result.cleanName = parts[0];
+
+    for (let i = 1; i < parts.length; i++) {
+        const part = parts[i];
+        const key = part.charAt(0).toLowerCase();
+        const value = parseInt(part.substring(1), 10);
+
+        if (isNaN(value) || value < 0 || value > 5) {
+            continue; // Ignore invalid or out-of-range values
+        }
+
+        if (key === 'f') {
+            result.forward = value;
+        } else if (key === 'b') {
+            result.backward = value;
+        }
+    }
+
+    return result;
+}

--- a/src/utils/chat/linkFetcher.ts
+++ b/src/utils/chat/linkFetcher.ts
@@ -1,0 +1,123 @@
+import { App, TFile } from 'obsidian';
+
+/**
+ * Performs a Breadth-First Search (BFS) on the link graph to a specified depth.
+ * @param startPath The starting file path.
+ * @param depth The recursion depth.
+ * @param getLinks A function that returns the links for a given path.
+ * @param app The Obsidian App instance.
+ * @returns A promise that resolves to an array of unique file paths.
+ */
+async function traverseLinks(
+  startPath: string,
+  depth: number,
+  getLinks: (path: string) => string[],
+  app: App,
+): Promise<string[]> {
+  if (depth <= 0) {
+    return [];
+  }
+
+  const queue: { path: string; level: number }[] = [{ path: startPath, level: 0 }];
+  const visited = new Set<string>([startPath]);
+  const allLinks = new Set<string>();
+
+  while (queue.length > 0) {
+    const { path, level } = queue.shift()!;
+
+    if (level >= depth) {
+      continue;
+    }
+
+    const newLinks = getLinks(path);
+
+    for (const link of newLinks) {
+      if (!visited.has(link)) {
+        visited.add(link);
+        allLinks.add(link);
+        queue.push({ path: link, level: level + 1 });
+      }
+    }
+  }
+
+  return Array.from(allLinks);
+}
+
+/**
+ * Fetches forward links from a given file to a specified depth.
+ * @param sourcePath The path of the source file.
+ * @param depth The recursion depth.
+ * @param app The Obsidian App instance.
+ * @returns A promise that resolves to an array of unique file paths.
+ */
+export async function getForwardLinks(sourcePath: string, depth: number, app: App): Promise<string[]> {
+  const getLinks = (path: string) => {
+    const file = app.vault.getAbstractFileByPath(path);
+    if (file instanceof TFile) {
+        const links = app.metadataCache.getCache(path)?.links ?? [];
+        return links.map(link => app.metadataCache.getFirstLinkpathDest(link.link, path)?.path).filter((p): p is string => !!p) ?? [];
+    }
+    return [];
+  };
+  return traverseLinks(sourcePath, depth, getLinks, app);
+}
+
+/**
+ * Fetches backward links to a given file to a specified depth.
+ * @param sourcePath The path of the source file.
+ * @param depth The recursion depth.
+ * @param app The Obsidian App instance.
+ * @returns A promise that resolves to an array of unique file paths.
+ */
+export async function getBackwardLinks(sourcePath: string, depth: number, app: App): Promise<string[]> {
+    const getLinks = (path: string): string[] => {
+        const file = app.vault.getAbstractFileByPath(path);
+        if (file instanceof TFile) {
+            const backlinks = app.metadataCache.getBacklinksForFile(file);
+            // The 'data' property is a Map where keys are the file paths of notes with backlinks.
+            return Array.from(backlinks.data.keys());
+        }
+        return [];
+    };
+
+    return traverseLinks(sourcePath, depth, getLinks, app);
+}
+
+
+/**
+ * Fetches and combines forward and backward linked notes.
+ * @param sourcePath The path of the source file.
+ * @param forwardDepth The depth for forward links.
+ * @param backwardDepth The depth for backward links.
+ * @param app The Obsidian App instance.
+ * @returns A promise that resolves to an array of unique file paths.
+ */
+export async function fetchLinkedNotes(
+    sourcePath: string,
+    forwardDepth: number,
+    backwardDepth: number,
+    app: App
+): Promise<string[]> {
+    const sourceFile = app.vault.getAbstractFileByPath(sourcePath);
+    if (!(sourceFile instanceof TFile)) {
+        console.error("Source path for link fetching is not a valid file:", sourcePath);
+        return [];
+    }
+    
+    const forwardLinks = forwardDepth > 0 ? await getForwardLinks(sourcePath, forwardDepth, app) : [];
+    const backwardLinks = backwardDepth > 0 ? await getBackwardLinks(sourcePath, backwardDepth, app) : [];
+
+    const allLinks = new Set([...forwardLinks, ...backwardLinks]);
+    
+    if (forwardDepth > 1) {
+        const secondOrderBackwardLinks = (await Promise.all(forwardLinks.map(link => getBackwardLinks(link, 1, app)))).flat();
+        secondOrderBackwardLinks.forEach(link => allLinks.add(link));
+    }
+
+    if (backwardDepth > 1) {
+        const secondOrderForwardLinks = (await Promise.all(backwardLinks.map(link => getForwardLinks(link, 1, app)))).flat();
+        secondOrderForwardLinks.forEach(link => allLinks.add(link));
+    }
+    
+    return Array.from(allLinks);
+}

--- a/styles.css
+++ b/styles.css
@@ -1,3 +1,5 @@
+/* styles.css */
+
 .smtcmp-chat-header {
   display: flex;
   justify-content: space-between;
@@ -323,10 +325,6 @@
   flex-grow: 1;
   overflow: hidden;
   align-items: center;
-}
-
-.smtcmp-chat-user-input-file-badge-name-icon {
-  color: var(--text-muted);
 }
 
 .smtcmp-chat-user-input-file-badge-name span {
@@ -952,28 +950,6 @@ button.smtcmp-chat-input-model-select {
   display: flex;
   align-items: center;
   justify-content: end;
-
-  /* button {
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    height: 20px;
-    width: 20px;
-    padding: 0;
-    background-color: transparent;
-    border-color: transparent;
-    box-shadow: none;
-    color: var(--text-faint);
-    cursor: pointer;
-
-    &:hover {
-      background-color: var(--background-modifier-hover);
-    }
-  }
-
-  .smtcmp-assistant-message-actions-icon--copied {
-    color: var(--text-muted);
-  } */
 }
 
 .smtcmp-popover-content {
@@ -1788,6 +1764,12 @@ button.smtcmp-chat-input-model-select {
 
 .smtcmp-continue-response-button {
   display: flex;
+  align-items: center;
+  gap: var(--size-4-1);
+}
+
+.smtcmp-depth-controls.compact {
+  display: inline-flex;
   align-items: center;
   gap: var(--size-4-1);
 }


### PR DESCRIPTION
## Description

Super happy to share this. It is my first real coding project (well, if I don't count modding for Stellaris and Skyrim!), so please be nice to me. I'm really happy with how it turned out. It was just for my own personal use, but I liked it so much I thought I'd make it available for everyone.

What's New: Context Linking

This update introduces Forward and Backward Linking.

This new feature automatically pulls in content from linked notes, giving the AI a much richer and smarter context for your chats. The linking work in the YAML frontmatter.

Key Features:

Granular Control: You can set how "deep" you want to follow links for each file, right from the chat input. Want to follow links 2 levels deep from NoteA.md but only 1 level from NoteB.md? No problem.

Intuitive UI: I've made it super easy with a compact, always-visible set of controls directly on the file "badges" in your chat. Adjust forward (-->) and backward (<--) link depths with just a click.

Active Note Settings: You can set a default link-fetching behavior specifically for the note you're currently viewing.


Duplicate Safe: The system's built to be clever about what it fetches, so no duplicate notes get sent to the AI. That helps keep your token usage in check.


If everything works well, I'll refine it a bit more, and maybe even try to make a pull request out of it, as soon as I figure out how to do that. Probably not today, though, as it's quite late here and I just finished the code!

I will also go through the code changes and put the comments back in as i am just too tired today to do this :)

I hope you have fun with this one and find it useful. I'd love to hear your feedback, like i said first real code ever.

And i'd like to say thank you to @Lapis0x0 who with his agent mode inspired me to make my own changes to smart composer, thanks man :) !

![Preview](https://github.com/user-attachments/assets/07d840b2-3fee-436c-9f5b-69c1c69b4bfa)


## Checklist before requesting a review
- [x ] I have reviewed the [guidelines for contributing](../CONTRIBUTING.md) to this repository.
- [x ] I have performed a self-review of my code
- [ ] I have performed a code linting check and type check (by running `npm run lint:check` and `npm run type:check`)
- [ ] I have run the test suite (by running `npm run test`)
- [x ] I have tested the functionality manually

