### PR TITLE
fix: Prevent cursor jumping and unnecessary re-renders in Obsidian components

### DIFF
--- a/src/components/common/ObsidianButton.tsx
+++ b/src/components/common/ObsidianButton.tsx
@@ -26,6 +26,7 @@ export function ObsidianButton({
   const { setting } = useObsidianSetting()
   const [buttonComponent, setButtonComponent] =
     useState<ButtonComponent | null>(null)
+  const onClickRef = useRef(onClick)
 
   useEffect(() => {
     if (setting) {
@@ -49,6 +50,15 @@ export function ObsidianButton({
   }, [setting])
 
   useEffect(() => {
+    onClickRef.current = onClick
+  }, [onClick])
+
+  useEffect(() => {
+    if (!buttonComponent) return
+    buttonComponent.onClick(() => onClickRef.current())
+  }, [buttonComponent])
+
+  useEffect(() => {
     if (!buttonComponent) return
 
     if (text) buttonComponent.setButtonText(text)
@@ -57,8 +67,7 @@ export function ObsidianButton({
     if (cta) buttonComponent.setCta()
     if (warning) buttonComponent.setWarning()
     buttonComponent.setDisabled(!!disabled)
-    buttonComponent.onClick(onClick)
-  }, [buttonComponent, text, icon, tooltip, onClick, cta, warning, disabled])
+  }, [buttonComponent, text, icon, tooltip, cta, warning, disabled])
 
   return <div ref={containerRef} />
 }

--- a/src/components/common/ObsidianDropdown.tsx
+++ b/src/components/common/ObsidianDropdown.tsx
@@ -18,6 +18,7 @@ export function ObsidianDropdown({
   const { setting } = useObsidianSetting()
   const [dropdownComponent, setDropdownComponent] =
     useState<DropdownComponent | null>(null)
+  const onChangeRef = useRef(onChange)
 
   useEffect(() => {
     if (setting) {
@@ -41,13 +42,21 @@ export function ObsidianDropdown({
   }, [setting])
 
   useEffect(() => {
+    onChangeRef.current = onChange
+  }, [onChange])
+
+  useEffect(() => {
+    if (!dropdownComponent) return
+    dropdownComponent.onChange((v) => onChangeRef.current(v))
+  }, [dropdownComponent])
+
+  useEffect(() => {
     if (!dropdownComponent) return
 
     dropdownComponent.selectEl.empty()
     dropdownComponent.addOptions(options)
     dropdownComponent.setValue(value)
-    dropdownComponent.onChange(onChange)
-  }, [dropdownComponent, options, value, onChange])
+  }, [dropdownComponent, options, value])
 
   return <div ref={containerRef} />
 }

--- a/src/components/common/ObsidianTextArea.tsx
+++ b/src/components/common/ObsidianTextArea.tsx
@@ -18,6 +18,7 @@ export function ObsidianTextArea({
   const { setting } = useObsidianSetting()
   const [textAreaComponent, setTextAreaComponent] =
     useState<TextAreaComponent | null>(null)
+  const onChangeRef = useRef(onChange)
 
   useEffect(() => {
     if (setting) {
@@ -41,12 +42,19 @@ export function ObsidianTextArea({
   }, [setting])
 
   useEffect(() => {
-    if (!textAreaComponent) return
+    onChangeRef.current = onChange
+  }, [onChange])
 
-    textAreaComponent.setValue(value)
+  useEffect(() => {
+    if (!textAreaComponent) return
+    textAreaComponent.onChange((v) => onChangeRef.current(v))
+  }, [textAreaComponent])
+
+  useEffect(() => {
+    if (!textAreaComponent) return
     if (placeholder) textAreaComponent.setPlaceholder(placeholder)
-    textAreaComponent.onChange(onChange)
-  }, [textAreaComponent, value, onChange, placeholder])
+    textAreaComponent.setValue(value)
+  }, [textAreaComponent, value, placeholder])
 
   return <div ref={containerRef} />
 }

--- a/src/components/common/ObsidianTextInput.tsx
+++ b/src/components/common/ObsidianTextInput.tsx
@@ -19,6 +19,7 @@ export function ObsidianTextInput({
   const containerRef = useRef<HTMLDivElement>(null)
   const { setting } = useObsidianSetting()
   const [textComponent, setTextComponent] = useState<TextComponent | null>(null)
+  const onChangeRef = useRef(onChange)
 
   useEffect(() => {
     if (setting) {
@@ -42,14 +43,20 @@ export function ObsidianTextInput({
   }, [setting])
 
   useEffect(() => {
-    if (!textComponent) return
+    onChangeRef.current = onChange
+  }, [onChange])
 
+  useEffect(() => {
+    if (!textComponent) return
+    textComponent.onChange((v) => onChangeRef.current(v))
+  }, [textComponent])
+
+  useEffect(() => {
+    if (!textComponent) return
     textComponent.setValue(value)
     if (placeholder) textComponent.setPlaceholder(placeholder)
-    textComponent.onChange(onChange)
-
     if (type) textComponent.inputEl.type = type
-  }, [textComponent, value, onChange, placeholder, type])
+  }, [textComponent, value, placeholder, type])
 
   return <div ref={containerRef} />
 }

--- a/src/components/common/ObsidianToggle.tsx
+++ b/src/components/common/ObsidianToggle.tsx
@@ -13,6 +13,7 @@ export function ObsidianToggle({ value, onChange }: ObsidianToggleProps) {
   const { setting } = useObsidianSetting()
   const [toggleComponent, setToggleComponent] =
     useState<ToggleComponent | null>(null)
+  const onChangeRef = useRef(onChange)
 
   useEffect(() => {
     if (setting) {
@@ -36,11 +37,18 @@ export function ObsidianToggle({ value, onChange }: ObsidianToggleProps) {
   }, [setting])
 
   useEffect(() => {
-    if (!toggleComponent) return
+    onChangeRef.current = onChange
+  }, [onChange])
 
+  useEffect(() => {
+    if (!toggleComponent) return
+    toggleComponent.onChange((v) => onChangeRef.current(v))
+  }, [toggleComponent])
+
+  useEffect(() => {
+    if (!toggleComponent) return
     toggleComponent.setValue(value)
-    toggleComponent.onChange(onChange)
-  }, [toggleComponent, value, onChange])
+  }, [toggleComponent, value])
 
   return <div ref={containerRef} style={{ display: 'contents' }} />
 }


### PR DESCRIPTION
Resolves #447 

## Description

- Fix cursor positioning issues in text inputs caused by frequent setValue calls
- Prevent unnecessary event handler re-registrations when parents pass inline callbacks
- Use ref pattern to stabilize onChange/onClick handlers across all Obsidian wrappers
- Separate event handler registration from property updates to avoid timing conflicts

Fixes issue where pressing Enter in textarea would cause cursor to jump back to first line due to setValue being called during onChange re-registration.

## Checklist before requesting a review
- [x] I have reviewed the [guidelines for contributing](../CONTRIBUTING.md) to this repository.
- [x] I have performed a self-review of my code
- [x] I have performed a code linting check and type check (by running `npm run lint:check` and `npm run type:check`)
- [x] I have run the test suite (by running `npm run test`)
- [x] I have tested the functionality manually


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - None
- Bug Fixes
  - Interactive controls (buttons, dropdowns, text inputs, text areas, toggles) now consistently use the latest callback, preventing stale handlers and missed interactions.
- Performance
  - Reduced unnecessary re-subscriptions on prop changes for common inputs, improving responsiveness and stability.
- Refactor
  - Standardized internal handler management across common UI components to decouple subscriptions from prop changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->