### PR TITLE
fix: avoid stream:false error in CodexMessageAdapter.generateResponse

### DIFF
--- a/src/core/llm/codexMessageAdapter.ts
+++ b/src/core/llm/codexMessageAdapter.ts
@@ -395,25 +395,25 @@ export class CodexMessageAdapter {
     const { input, instructions } = buildResponsesInput(request.messages)
     const tools = request.tools
       ? request.tools.map(
-        (tool): FunctionTool => ({
-          type: 'function',
-          name: tool.function.name,
-          description: tool.function.description ?? null,
-          parameters: tool.function.parameters,
-          strict: false,
-        }),
-      )
+          (tool): FunctionTool => ({
+            type: 'function',
+            name: tool.function.name,
+            description: tool.function.description ?? null,
+            parameters: tool.function.parameters,
+            strict: false,
+          }),
+        )
       : undefined
     const reasoning =
       request.reasoning_effort || request.reasoning_summary
         ? {
-          ...(request.reasoning_effort && {
-            effort: request.reasoning_effort,
-          }),
-          ...(request.reasoning_summary && {
-            summary: request.reasoning_summary,
-          }),
-        }
+            ...(request.reasoning_effort && {
+              effort: request.reasoning_effort,
+            }),
+            ...(request.reasoning_summary && {
+              summary: request.reasoning_summary,
+            }),
+          }
         : undefined
 
     const body: ResponseCreateParamsBase = {
@@ -590,7 +590,10 @@ function accumulateResponseSnapshot(
       const part = event.part
       if (output.type === 'message' && part.type !== 'reasoning_text') {
         output.content.push(part)
-      } else if (output.type === 'reasoning' && part.type === 'reasoning_text') {
+      } else if (
+        output.type === 'reasoning' &&
+        part.type === 'reasoning_text'
+      ) {
         if (!output.content) {
           output.content = []
         }


### PR DESCRIPTION
## Description
Avoid `stream:false` in CodexMessageAdapter.generateResponse since Codex endpoint always requires `stream:true`.

## Checklist before requesting a review
- [x] I have reviewed the [guidelines for contributing](../CONTRIBUTING.md) to this repository.
- [x] I have performed a self-review of my code
- [x] I have performed a code linting check and type check (by running `npm run lint:check` and `npm run type:check`)
- [x] I have run the test suite (by running `npm run test`)
- [x] I have tested the functionality manually


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Responses now stream incrementally, displaying results progressively as they arrive instead of waiting for complete response assembly.
  * Added support for non-blocking, chunked response delivery.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->