### PR TITLE
Add inline diff highlighting and side by side rendering with bulk actions

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -135,6 +135,7 @@
       "version": "7.25.7",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@ampproject/remapping": "^2.2.0",
         "@babel/code-frame": "^7.25.7",
@@ -627,7 +628,8 @@
     "node_modules/@electric-sql/pglite": {
       "version": "0.2.12",
       "resolved": "https://registry.npmjs.org/@electric-sql/pglite/-/pglite-0.2.12.tgz",
-      "integrity": "sha512-J/X42ujcoFEbOkgRyoNqZB5qcqrnJRWVlwpH3fKYoJkTz49N91uAK/rDSSG/85WRas9nC9mdV4FnMTxnQWE/rw=="
+      "integrity": "sha512-J/X42ujcoFEbOkgRyoNqZB5qcqrnJRWVlwpH3fKYoJkTz49N91uAK/rDSSG/85WRas9nC9mdV4FnMTxnQWE/rw==",
+      "peer": true
     },
     "node_modules/@esbuild-kit/core-utils": {
       "version": "3.3.2",
@@ -1800,7 +1802,6 @@
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
       "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
-      "peer": true,
       "engines": {
         "node": ">=10"
       },
@@ -1812,7 +1813,6 @@
       "version": "6.3.0",
       "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-6.3.0.tgz",
       "integrity": "sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA==",
-      "peer": true,
       "engines": {
         "node": ">=10"
       },
@@ -2105,14 +2105,14 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/@marijn/find-cluster-break/-/find-cluster-break-1.0.2.tgz",
       "integrity": "sha512-l0h88YhZFyKdXIFNfSWpyjStDjGHwZ/U7iobcK1cQQD8sejsONdQtTVU+1wVN1PBw40PiiHB1vA5S7VTfQiP9g==",
-      "dev": true,
-      "peer": true
+      "dev": true
     },
     "node_modules/@modelcontextprotocol/sdk": {
       "version": "1.25.2",
       "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.25.2.tgz",
       "integrity": "sha512-LZFeo4F9M5qOhC/Uc1aQSrBHxMrvxett+9KLHt7OhcExtoiRN9DKgbZffMP/nxjutWDQpfMDfP3nkHI4X9ijww==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@hono/node-server": "^1.19.7",
         "ajv": "^8.17.1",
@@ -2174,6 +2174,7 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.5.tgz",
       "integrity": "sha512-k7Nwx6vuWx1IJ9Bjuf4Zt1PEllcwe7cls3VNzm4CQ1/hgtFUK2bRNG3rvnpPUhFjmqJKAKtjV576KnUkHocg/g==",
       "license": "MIT",
+      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }
@@ -3087,6 +3088,7 @@
     "node_modules/@types/react": {
       "version": "18.3.10",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/prop-types": "*",
         "csstype": "^3.0.2"
@@ -3096,6 +3098,7 @@
       "version": "18.3.0",
       "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/react": "*"
       }
@@ -3189,6 +3192,7 @@
       "version": "5.29.0",
       "dev": true,
       "license": "BSD-2-Clause",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "5.29.0",
         "@typescript-eslint/types": "5.29.0",
@@ -3378,6 +3382,7 @@
       "version": "8.12.1",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -3922,6 +3927,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "caniuse-lite": "^1.0.30001663",
         "electron-to-chromium": "^1.5.28",
@@ -4302,8 +4308,7 @@
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/crelt/-/crelt-1.0.6.tgz",
       "integrity": "sha512-VQ2MBenTq1fWZUH9DJNGti7kKv6EeAuYr3cLwxUWhIu1baTaXh4Ib5W2CqHVqib4/MqbYGJqiL3Zb8GJZr3l4g==",
-      "dev": true,
-      "peer": true
+      "dev": true
     },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
@@ -4404,7 +4409,6 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
       "integrity": "sha512-z2S+W9X73hAUUki+N+9Za2lBlun89zigOyGrsax+KUQ6wKW4ZoWpEYBkGhQjwAjjDCkWxhY0VKEhk8wzY7F5cA==",
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -5351,6 +5355,7 @@
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "esbuild": "bin/esbuild"
       },
@@ -5758,6 +5763,7 @@
       "version": "8.57.1",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.6.1",
@@ -7937,7 +7943,6 @@
       "version": "0.2.5",
       "resolved": "https://registry.npmjs.org/isomorphic.js/-/isomorphic.js-0.2.5.tgz",
       "integrity": "sha512-PIeMbHqMt4DnUP3MA/Flc0HElYjMXArsw1qwJZcm9sqR8mq3l8NYizFMty0pWwE/tzIGH3EKK5+jes5mAr85yw==",
-      "peer": true,
       "funding": {
         "type": "GitHub Sponsors ❤",
         "url": "https://github.com/sponsors/dmonad"
@@ -8077,6 +8082,7 @@
       "version": "29.7.0",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@jest/core": "^29.7.0",
         "@jest/types": "^29.6.3",
@@ -8992,7 +8998,6 @@
       "version": "0.2.117",
       "resolved": "https://registry.npmjs.org/lib0/-/lib0-0.2.117.tgz",
       "integrity": "sha512-DeXj9X5xDCjgKLU/7RR+/HQEVzuuEUiwldwOGsHK/sfAfELGWEyTcf0x+uOvCvK3O2zPmZePXWL85vtia6GyZw==",
-      "peer": true,
       "dependencies": {
         "isomorphic.js": "^0.2.4"
       },
@@ -10005,7 +10010,6 @@
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/mustache/-/mustache-4.2.0.tgz",
       "integrity": "sha512-71ippSywq5Yb7/tVYyGbkBggbU8H3u5Rz56fH60jGFgr8uHwxs+aSKeqmluIVzM0m0kB7xQjKS6qPfd0b2ZoqQ==",
-      "peer": true,
       "bin": {
         "mustache": "bin/mustache"
       }
@@ -10237,6 +10241,7 @@
       "version": "6.16.0",
       "resolved": "https://registry.npmjs.org/openai/-/openai-6.16.0.tgz",
       "integrity": "sha512-fZ1uBqjFUjXzbGc35fFtYKEOxd20kd9fDpFeqWtsOZWiubY8CZ1NAlXHW3iathaFvqmNtCWMIsosCuyeI7Joxg==",
+      "peer": true,
       "bin": {
         "openai": "bin/cli"
       },
@@ -10796,6 +10801,7 @@
     "node_modules/react": {
       "version": "18.3.1",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0"
       },
@@ -10806,6 +10812,7 @@
     "node_modules/react-dom": {
       "version": "18.3.1",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0",
         "scheduler": "^0.23.2"
@@ -11865,8 +11872,7 @@
       "version": "4.1.3",
       "resolved": "https://registry.npmjs.org/style-mod/-/style-mod-4.1.3.tgz",
       "integrity": "sha512-i/n8VsZydrugj3Iuzll8+x/00GH2vnYsk1eomD8QiRrSAeW6ItbCQDtfXCeJHd0iwiNagqjQkvpvREEPtW3IoQ==",
-      "dev": true,
-      "peer": true
+      "dev": true
     },
     "node_modules/style-to-object": {
       "version": "1.0.8",
@@ -12207,6 +12213,7 @@
       "version": "5.6.2",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -12499,8 +12506,7 @@
       "version": "2.2.8",
       "resolved": "https://registry.npmjs.org/w3c-keyname/-/w3c-keyname-2.2.8.tgz",
       "integrity": "sha512-dpojBhNsCNN7T82Tm7k26A6G9ML3NkhDsnw9n/eoxSRlVBB4CEtIQ/KTCLI2Fwf3ataSXRhYFkQi3SlnFwPvPQ==",
-      "dev": true,
-      "peer": true
+      "dev": true
     },
     "node_modules/walker": {
       "version": "1.0.8",
@@ -12772,6 +12778,7 @@
       "version": "3.25.76",
       "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
       "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
+      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/src/components/apply-view/ApplyViewRoot.tsx
+++ b/src/components/apply-view/ApplyViewRoot.tsx
@@ -334,22 +334,29 @@ const DiffBlockView = forwardRef<
       </div>
     )
   } else if (part.type === 'modified') {
+    const renderSide = (
+      value: string | undefined,
+      tokens: InlineToken[] | undefined,
+      sideClass: string,
+    ) => {
+      if (!value || value.length === 0) {
+        return <div className={`smtcmp-diff-block ${sideClass} smtcmp-diff-empty`} />
+      }
+      return (
+        <div className={`smtcmp-diff-block ${sideClass}`}>
+          <div style={{ width: '100%' }}>
+            {renderInlineTokens(tokens, value)}
+          </div>
+        </div>
+      )
+    }
+
     return (
       <div className="smtcmp-diff-block-container" ref={ref}>
-        {part.originalValue && part.originalValue.length > 0 && (
-          <div className="smtcmp-diff-block removed">
-            <div style={{ width: '100%' }}>
-              {renderInlineTokens(part.originalTokens, part.originalValue)}
-            </div>
-          </div>
-        )}
-        {part.modifiedValue && part.modifiedValue.length > 0 && (
-          <div className="smtcmp-diff-block added">
-            <div style={{ width: '100%' }}>
-              {renderInlineTokens(part.modifiedTokens, part.modifiedValue)}
-            </div>
-          </div>
-        )}
+        <div className="smtcmp-diff-block-grid">
+          {renderSide(part.originalValue, part.originalTokens, 'removed')}
+          {renderSide(part.modifiedValue, part.modifiedTokens, 'added')}
+        </div>
         <div className="smtcmp-diff-block-actions">
           <button onClick={onAcceptIncoming} className="smtcmp-accept">
             Accept Incoming

--- a/src/utils/chat/diff.test.ts
+++ b/src/utils/chat/diff.test.ts
@@ -1,0 +1,43 @@
+import { createDiffBlocks } from './diff'
+
+const getFirstModifiedBlock = (original: string, modified: string) => {
+  const blocks = createDiffBlocks(original, modified)
+  const modifiedBlock = blocks.find((block) => block.type === 'modified')
+  if (!modifiedBlock || modifiedBlock.type !== 'modified') {
+    throw new Error('Expected a modified block')
+  }
+  return modifiedBlock
+}
+
+describe('createDiffBlocks inline tokens', () => {
+  it('marks inserted words as added tokens', () => {
+    const block = getFirstModifiedBlock(
+      'Hello world',
+      'Hello brave world',
+    )
+    const added = block.modifiedTokens?.find(
+      (token) => token.kind === 'added' && token.text.includes('brave'),
+    )
+    expect(added).toBeTruthy()
+  })
+
+  it('marks replaced words with removed/added tokens', () => {
+    const block = getFirstModifiedBlock('Hello world', 'Hello earth')
+    const removed = block.originalTokens?.find(
+      (token) => token.kind === 'removed',
+    )
+    const added = block.modifiedTokens?.find(
+      (token) => token.kind === 'added',
+    )
+    expect(removed).toBeTruthy()
+    expect(added).toBeTruthy()
+  })
+
+  it('uses character-level highlights for small replacements', () => {
+    const block = getFirstModifiedBlock('color', 'colour')
+    const added = block.modifiedTokens?.find(
+      (token) => token.kind === 'added' && token.text.includes('u'),
+    )
+    expect(added).toBeTruthy()
+  })
+})

--- a/src/utils/chat/diff.test.ts
+++ b/src/utils/chat/diff.test.ts
@@ -40,4 +40,16 @@ describe('createDiffBlocks inline tokens', () => {
     )
     expect(added).toBeTruthy()
   })
+
+  it('keeps word-level replacement for dissimilar words', () => {
+    const block = getFirstModifiedBlock('horse', 'companion')
+    const removed = block.originalTokens?.find(
+      (token) => token.kind === 'removed' && token.text.includes('horse'),
+    )
+    const added = block.modifiedTokens?.find(
+      (token) => token.kind === 'added' && token.text.includes('companion'),
+    )
+    expect(removed).toBeTruthy()
+    expect(added).toBeTruthy()
+  })
 })

--- a/src/utils/chat/diff.ts
+++ b/src/utils/chat/diff.ts
@@ -13,7 +13,152 @@ export type DiffBlock =
       type: 'modified'
       originalValue?: string
       modifiedValue?: string
+      originalTokens?: InlineToken[]
+      modifiedTokens?: InlineToken[]
     }
+
+export type InlineToken = {
+  text: string
+  kind: 'equal' | 'added' | 'removed'
+}
+
+type DiffOp = {
+  type: 'equal' | 'insert' | 'delete'
+  value: string
+}
+
+const INLINE_DIFF_MAX_TOKENS = 300
+const INLINE_DIFF_MAX_CHARS = 800
+
+const tokenizeByWord = (value: string): string[] => {
+  if (!value) return []
+  const matches = value.match(/(\s+|[^\s]+)/g)
+  return matches ?? []
+}
+
+const pushInlineToken = (
+  tokens: InlineToken[],
+  kind: InlineToken['kind'],
+  text: string,
+) => {
+  if (!text) return
+  const last = tokens[tokens.length - 1]
+  if (last && last.kind === kind) {
+    last.text += text
+    return
+  }
+  tokens.push({ text, kind })
+}
+
+const diffSequence = (original: string[], modified: string[]): DiffOp[] => {
+  const rows = original.length + 1
+  const cols = modified.length + 1
+  const dp: number[][] = Array.from({ length: rows }, () =>
+    new Array(cols).fill(0),
+  )
+  const dir: number[][] = Array.from({ length: rows }, () =>
+    new Array(cols).fill(0),
+  )
+
+  for (let i = 1; i < rows; i++) {
+    for (let j = 1; j < cols; j++) {
+      if (original[i - 1] === modified[j - 1]) {
+        dp[i][j] = dp[i - 1][j - 1] + 1
+        dir[i][j] = 1
+      } else if (dp[i - 1][j] >= dp[i][j - 1]) {
+        dp[i][j] = dp[i - 1][j]
+        dir[i][j] = 2
+      } else {
+        dp[i][j] = dp[i][j - 1]
+        dir[i][j] = 3
+      }
+    }
+  }
+
+  const ops: DiffOp[] = []
+  let i = original.length
+  let j = modified.length
+  while (i > 0 || j > 0) {
+    if (i > 0 && j > 0 && dir[i][j] === 1) {
+      ops.push({ type: 'equal', value: original[i - 1] })
+      i -= 1
+      j -= 1
+    } else if (i > 0 && (j === 0 || dir[i][j] === 2)) {
+      ops.push({ type: 'delete', value: original[i - 1] })
+      i -= 1
+    } else if (j > 0) {
+      ops.push({ type: 'insert', value: modified[j - 1] })
+      j -= 1
+    }
+  }
+
+  return ops.reverse()
+}
+
+const buildInlineTokens = (
+  originalValue?: string,
+  modifiedValue?: string,
+): { originalTokens: InlineToken[]; modifiedTokens: InlineToken[] } | null => {
+  const originalText = originalValue ?? ''
+  const modifiedText = modifiedValue ?? ''
+  if (!originalText && !modifiedText) return null
+
+  const originalTokens = tokenizeByWord(originalText)
+  const modifiedTokens = tokenizeByWord(modifiedText)
+  if (originalTokens.length + modifiedTokens.length > INLINE_DIFF_MAX_TOKENS) {
+    return null
+  }
+
+  const ops = diffSequence(originalTokens, modifiedTokens)
+  const originalInline: InlineToken[] = []
+  const modifiedInline: InlineToken[] = []
+
+  for (let index = 0; index < ops.length; index++) {
+    const op = ops[index]
+    if (op.type === 'equal') {
+      pushInlineToken(originalInline, 'equal', op.value)
+      pushInlineToken(modifiedInline, 'equal', op.value)
+      continue
+    }
+
+    let deletes = ''
+    let inserts = ''
+    let j = index
+    while (j < ops.length && ops[j].type !== 'equal') {
+      if (ops[j].type === 'delete') {
+        deletes += ops[j].value
+      } else if (ops[j].type === 'insert') {
+        inserts += ops[j].value
+      }
+      j += 1
+    }
+
+    if (deletes && inserts && deletes.length + inserts.length <= INLINE_DIFF_MAX_CHARS) {
+      const charOps = diffSequence(deletes.split(''), inserts.split(''))
+      charOps.forEach((charOp) => {
+        if (charOp.type === 'equal') {
+          pushInlineToken(originalInline, 'equal', charOp.value)
+          pushInlineToken(modifiedInline, 'equal', charOp.value)
+        } else if (charOp.type === 'delete') {
+          pushInlineToken(originalInline, 'removed', charOp.value)
+        } else if (charOp.type === 'insert') {
+          pushInlineToken(modifiedInline, 'added', charOp.value)
+        }
+      })
+    } else {
+      if (deletes) {
+        pushInlineToken(originalInline, 'removed', deletes)
+      }
+      if (inserts) {
+        pushInlineToken(modifiedInline, 'added', inserts)
+      }
+    }
+
+    index = j - 1
+  }
+
+  return { originalTokens: originalInline, modifiedTokens: modifiedInline }
+}
 
 export function createDiffBlocks(
   currentMarkdown: string,
@@ -60,10 +205,19 @@ export function createDiffBlocks(
     const originalValue = currentLines.slice(oStart - 1, oEnd - 1).join('\n')
     const modifiedValue = incomingLines.slice(mStart - 1, mEnd - 1).join('\n')
     if (originalValue.length > 0 || modifiedValue.length > 0) {
+      const inlineTokens = buildInlineTokens(originalValue, modifiedValue)
       blocks.push({
         type: 'modified',
         originalValue: originalValue.length > 0 ? originalValue : undefined,
         modifiedValue: modifiedValue.length > 0 ? modifiedValue : undefined,
+        originalTokens:
+          inlineTokens && originalValue.length > 0
+            ? inlineTokens.originalTokens
+            : undefined,
+        modifiedTokens:
+          inlineTokens && modifiedValue.length > 0
+            ? inlineTokens.modifiedTokens
+            : undefined,
       })
     }
 

--- a/styles.css
+++ b/styles.css
@@ -667,14 +667,16 @@ input[type='text'].smtcmp-chat-list-dropdown-item-title-input {
     gap: var(--size-4-1);
     color: var(--text-normal);
     line-height: var(--line-height-normal);
+    border-radius: var(--radius-s);
+    padding: var(--size-4-2);
   }
 
   .smtcmp-diff-block.added {
-    background-color: rgba(var(--smtcmp-incoming-color-rgb), 0.3);
+    background-color: rgba(var(--smtcmp-incoming-color-rgb), 0.18);
   }
 
   .smtcmp-diff-block.removed {
-    background-color: rgba(var(--smtcmp-current-color-rgb), 0.3);
+    background-color: rgba(var(--smtcmp-current-color-rgb), 0.18);
   }
 
   .smtcmp-diff-block-grid {
@@ -715,17 +717,20 @@ input[type='text'].smtcmp-chat-list-dropdown-item-title-input {
   .smtcmp-diff-block-container {
     position: relative;
     scroll-margin-top: var(--size-4-8);
+    padding-top: var(--size-4-6);
+    padding-bottom: var(--size-4-4);
   }
 
   .smtcmp-diff-block-actions {
     position: absolute;
     right: 0;
-    top: 0;
-    transform: translateY(-100%);
+    top: var(--size-4-1);
+    transform: none;
     display: flex;
     gap: 0;
     border-radius: var(--radius-s) var(--radius-s) 0 0;
     overflow: hidden;
+    z-index: 2;
 
     button {
       padding: var(--size-4-1) var(--size-4-2);

--- a/styles.css
+++ b/styles.css
@@ -676,6 +676,18 @@ input[type='text'].smtcmp-chat-list-dropdown-item-title-input {
     background-color: rgba(var(--smtcmp-current-color-rgb), 0.3);
   }
 
+  .smtcmp-diff-inline-added {
+    background-color: rgba(var(--smtcmp-incoming-color-rgb), 0.45);
+    border-radius: var(--radius-s);
+    padding: 0 1px;
+  }
+
+  .smtcmp-diff-inline-removed {
+    background-color: rgba(var(--smtcmp-current-color-rgb), 0.45);
+    border-radius: var(--radius-s);
+    padding: 0 1px;
+  }
+
   .smtcmp-diff-block-container {
     position: relative;
     scroll-margin-top: var(--size-4-8);

--- a/styles.css
+++ b/styles.css
@@ -587,6 +587,7 @@ input[type='text'].smtcmp-chat-list-dropdown-item-title-input {
   display: flex;
   flex-direction: column;
   font-family: var(--font-interface);
+  container-type: inline-size;
 
   --smtcmp-current-color-rgb: 185, 28, 28; /* red-700 */
   --smtcmp-incoming-color-rgb: 4, 120, 87; /* emerald-700 */
@@ -674,6 +675,29 @@ input[type='text'].smtcmp-chat-list-dropdown-item-title-input {
 
   .smtcmp-diff-block.removed {
     background-color: rgba(var(--smtcmp-current-color-rgb), 0.3);
+  }
+
+  .smtcmp-diff-block-grid {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: var(--size-4-4);
+  }
+
+  .smtcmp-diff-empty {
+    background: transparent;
+    min-height: var(--size-4-8);
+  }
+
+  @media (max-width: 700px) {
+    .smtcmp-diff-block-grid {
+      grid-template-columns: 1fr;
+    }
+  }
+
+  @container (max-width: 700px) {
+    .smtcmp-diff-block-grid {
+      grid-template-columns: 1fr;
+    }
   }
 
   .smtcmp-diff-inline-added {


### PR DESCRIPTION
## Description

This PR enhances the Apply view diff experience with several user-facing improvements: inline word/character highlighting for edits (with smarter similarity handling to avoid odd partial highlights), side‑by‑side diff rendering that collapses responsively in narrow panes, and clearer bulk actions that let you Accept All or Reject All remaining changes while preserving previously accepted/rejected blocks. It also refines the visual presentation with adjusted diff block styling and action placement, and ensures paragraph spacing is preserved when applying or rejecting changes.

Feat:
#478 

<img width="1770" height="1137" alt="image" src="https://github.com/user-attachments/assets/b2af24f9-cc6c-44d7-b4a0-be83c91aa46d" />


## Checklist before requesting a review
- [X ] I have reviewed the [guidelines for contributing](../CONTRIBUTING.md) to this repository.
- [X ] I have performed a self-review of my code
- [X ] I have performed a code linting check and type check (by running `npm run lint:check` and `npm run type:check`)
- [X ] I have run the test suite (by running `npm run test`)
- [X ] I have tested the functionality manually


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added bulk action buttons to Accept All Remaining Changes or Reject All Remaining Changes at once
  * Introduced inline diff highlighting that displays character and word-level modifications with clear visual distinction

* **Style**
  * Refined diff block appearance with improved backgrounds and visual hierarchy
  * Enhanced responsive layout for optimal display across all device sizes

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->