### PR TITLE
fix: support custom base URL for Gemini provider

### DIFF
--- a/src/core/llm/gemini.ts
+++ b/src/core/llm/gemini.ts
@@ -201,24 +201,24 @@ export class GeminiProvider extends BaseLLMProvider<
       case 'user': {
         const contentParts: Part[] = Array.isArray(message.content)
           ? message.content.map((part) => {
-            switch (part.type) {
-              case 'text':
-                return { text: part.text }
-              case 'image_url': {
-                const { mimeType, base64Data } = parseImageDataUrl(
-                  part.image_url.url,
-                )
-                GeminiProvider.validateImageType(mimeType)
+              switch (part.type) {
+                case 'text':
+                  return { text: part.text }
+                case 'image_url': {
+                  const { mimeType, base64Data } = parseImageDataUrl(
+                    part.image_url.url,
+                  )
+                  GeminiProvider.validateImageType(mimeType)
 
-                return {
-                  inlineData: {
-                    data: base64Data,
-                    mimeType,
-                  },
+                  return {
+                    inlineData: {
+                      data: base64Data,
+                      mimeType,
+                    },
+                  }
                 }
               }
-            }
-          })
+            })
           : [{ text: message.content }]
 
         return {
@@ -326,10 +326,10 @@ export class GeminiProvider extends BaseLLMProvider<
       object: 'chat.completion',
       usage: response.usageMetadata
         ? {
-          prompt_tokens: response.usageMetadata.promptTokenCount ?? 0,
-          completion_tokens: response.usageMetadata.candidatesTokenCount ?? 0,
-          total_tokens: response.usageMetadata.totalTokenCount ?? 0,
-        }
+            prompt_tokens: response.usageMetadata.promptTokenCount ?? 0,
+            completion_tokens: response.usageMetadata.candidatesTokenCount ?? 0,
+            total_tokens: response.usageMetadata.totalTokenCount ?? 0,
+          }
         : undefined,
     }
   }
@@ -365,10 +365,10 @@ export class GeminiProvider extends BaseLLMProvider<
       object: 'chat.completion.chunk',
       usage: chunk.usageMetadata
         ? {
-          prompt_tokens: chunk.usageMetadata.promptTokenCount ?? 0,
-          completion_tokens: chunk.usageMetadata.candidatesTokenCount ?? 0,
-          total_tokens: chunk.usageMetadata.totalTokenCount ?? 0,
-        }
+            prompt_tokens: chunk.usageMetadata.promptTokenCount ?? 0,
+            completion_tokens: chunk.usageMetadata.candidatesTokenCount ?? 0,
+            total_tokens: chunk.usageMetadata.totalTokenCount ?? 0,
+          }
         : undefined,
     }
   }


### PR DESCRIPTION
Fixes #512

## Description

The Gemini provider was throwing an error when a custom base URL was set, causing the chat interface to crash. The @google/genai SDK actually supports custom base URLs via the httpOptions.baseUrl configuration.

This change removes the error and passes the custom base URL to the SDK, enabling users to use custom Gemini-compatible endpoints (like proxies or self-hosted alternatives).

## Checklist before requesting a review
- [x] I have reviewed the [guidelines for contributing](../CONTRIBUTING.md) to this repository.
- [x] I have performed a self-review of my code
- [x] I have performed a code linting check and type check (by running `npm run lint:check` and `npm run type:check`)
- [x] I have run the test suite (by running `npm run test`)
- [x] I have tested the functionality manually


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Support for configuring a custom base URL for AI service requests, improving deployment flexibility.

* **Improvements**
  * Base URL handling now trims trailing slashes and accepts custom values; no other runtime behavior changes to message parsing or error semantics.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->