### PR TITLE
feat: add Copy/Apply buttons at bottom of code blocks

### DIFF
--- a/src/components/chat-view/MarkdownCodeComponent.tsx
+++ b/src/components/chat-view/MarkdownCodeComponent.tsx
@@ -124,6 +124,51 @@ export default function MarkdownCodeComponent({
           {String(children)}
         </MemoizedSyntaxHighlighterWrapper>
       )}
+      <div className="smtcmp-code-block-footer">
+        <div className="smtcmp-code-block-header-button-container">
+          <button
+            className="clickable-icon smtcmp-code-block-header-button"
+            onClick={() => {
+              handleCopy()
+            }}
+          >
+            {copied ? (
+              <>
+                <Check size={10} />
+                <span>Copied</span>
+              </>
+            ) : (
+              <>
+                <CopyIcon size={10} />
+                <span>Copy</span>
+              </>
+            )}
+          </button>
+          <button
+            className="clickable-icon smtcmp-code-block-header-button"
+            onClick={
+              isApplying
+                ? undefined
+                : () => {
+                    onApply(String(children))
+                  }
+            }
+            aria-disabled={isApplying}
+          >
+            {isApplying ? (
+              <>
+                <Loader2 className="spinner" size={14} />
+                <span>Applying...</span>
+              </>
+            ) : (
+              <>
+                <Play size={10} />
+                <span>Apply</span>
+              </>
+            )}
+          </button>
+        </div>
+      </div>
     </div>
   )
 }

--- a/styles.css
+++ b/styles.css
@@ -582,6 +582,17 @@ input[type='text'].smtcmp-chat-list-dropdown-item-title-input {
   padding: var(--size-4-3);
 }
 
+.smtcmp-code-block-footer {
+  display: flex;
+  justify-content: flex-end;
+  align-items: center;
+  font-size: var(--font-smallest);
+  border-top: 1px solid var(--background-modifier-border);
+  background-color: var(--background-primary);
+  border-radius: 0 0 var(--radius-s) var(--radius-s);
+  height: calc(var(--size-4-8) - var(--size-4-1));
+}
+
 #smtcmp-apply-view {
   flex: 1 1 auto;
   display: flex;


### PR DESCRIPTION
Closes #498

## Description

- Added footer section with Copy and Apply buttons below code block content
- Allows users to execute actions without scrolling back to the top
- Reuses existing header button styles for consistency

## Checklist before requesting a review
- [x] I have reviewed the [guidelines for contributing](../CONTRIBUTING.md) to this repository.
- [x] I have performed a self-review of my code
- [x] I have performed a code linting check and type check (by running `npm run lint:check` and `npm run type:check`)
- [x] I have run the test suite (by running `npm run test`)
- [x] I have tested the functionality manually


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Code blocks now include a footer section with Copy and Apply action buttons. The Copy button provides confirmation feedback, while the Apply button executes code changes. These footer controls duplicate existing header actions, offering multiple access points for user convenience.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->