### PR TITLE
feat: support output dimensions for embedding models (#490)

### DIFF
--- a/src/core/llm/anthropic.ts
+++ b/src/core/llm/anthropic.ts
@@ -603,7 +603,11 @@ https://github.com/glowingjade/obsidian-smart-composer/issues/286`,
     throw new Error(`Unsupported tool choice: ${JSON.stringify(toolChoice)}`)
   }
 
-  async getEmbedding(_model: string, _text: string): Promise<number[]> {
+  async getEmbedding(
+    _model: string,
+    _text: string,
+    _options?: { dimensions?: number },
+  ): Promise<number[]> {
     throw new Error(
       `Provider ${this.provider.id} does not support embeddings. Please use a different provider.`,
     )

--- a/src/core/llm/anthropicClaudeCodeProvider.ts
+++ b/src/core/llm/anthropicClaudeCodeProvider.ts
@@ -77,7 +77,11 @@ export class AnthropicClaudeCodeProvider extends BaseLLMProvider<
     )
   }
 
-  async getEmbedding(_model: string, _text: string): Promise<number[]> {
+  async getEmbedding(
+    _model: string,
+    _text: string,
+    _options?: { dimensions?: number },
+  ): Promise<number[]> {
     throw new Error(
       `Provider ${this.provider.id} does not support embeddings. Please use a different provider.`,
     )

--- a/src/core/llm/azureOpenaiProvider.ts
+++ b/src/core/llm/azureOpenaiProvider.ts
@@ -57,7 +57,11 @@ export class AzureOpenAIProvider extends BaseLLMProvider<
     return this.adapter.streamResponse(this.client, request, options)
   }
 
-  async getEmbedding(_model: string, _text: string): Promise<number[]> {
+  async getEmbedding(
+    _model: string,
+    _text: string,
+    _options?: { dimensions?: number },
+  ): Promise<number[]> {
     throw new Error(
       `Provider ${this.provider.id} does not support embeddings. Please use a different provider.`,
     )

--- a/src/core/llm/base.ts
+++ b/src/core/llm/base.ts
@@ -29,5 +29,9 @@ export abstract class BaseLLMProvider<P extends LLMProvider> {
     options?: LLMOptions,
   ): Promise<AsyncIterable<LLMResponseStreaming>>
 
-  abstract getEmbedding(model: string, text: string): Promise<number[]>
+  abstract getEmbedding(
+    model: string,
+    text: string,
+    options?: { dimensions?: number },
+  ): Promise<number[]>
 }

--- a/src/core/llm/deepseekStudioProvider.ts
+++ b/src/core/llm/deepseekStudioProvider.ts
@@ -80,7 +80,11 @@ export class DeepSeekStudioProvider extends BaseLLMProvider<
     return this.adapter.streamResponse(this.client, formattedRequest, options)
   }
 
-  async getEmbedding(_model: string, _text: string): Promise<number[]> {
+  async getEmbedding(
+    _model: string,
+    _text: string,
+    _options?: { dimensions?: number },
+  ): Promise<number[]> {
     throw new Error(
       `Provider ${this.provider.id} does not support embeddings. Please use a different provider.`,
     )

--- a/src/core/llm/gemini.ts
+++ b/src/core/llm/gemini.ts
@@ -541,7 +541,11 @@ export class GeminiProvider extends BaseLLMProvider<
     return config
   }
 
-  async getEmbedding(model: string, text: string): Promise<number[]> {
+  async getEmbedding(
+    model: string,
+    text: string,
+    options?: { dimensions?: number },
+  ): Promise<number[]> {
     if (!this.apiKey) {
       throw new LLMAPIKeyNotSetException(
         `Provider ${this.provider.id} API key is missing. Please set it in settings menu.`,
@@ -552,6 +556,9 @@ export class GeminiProvider extends BaseLLMProvider<
       const response = await this.client.models.embedContent({
         model: model,
         contents: text,
+        ...(options?.dimensions && {
+          config: { outputDimensionality: options.dimensions },
+        }),
       })
       return response.embeddings?.[0]?.values ?? []
     } catch (error) {

--- a/src/core/llm/geminiPlanProvider.ts
+++ b/src/core/llm/geminiPlanProvider.ts
@@ -79,7 +79,11 @@ export class GeminiPlanProvider extends BaseLLMProvider<
     )
   }
 
-  async getEmbedding(_model: string, _text: string): Promise<number[]> {
+  async getEmbedding(
+    _model: string,
+    _text: string,
+    _options?: { dimensions?: number },
+  ): Promise<number[]> {
     throw new Error(
       `Provider ${this.provider.id} does not support embeddings. Please use a different provider.`,
     )

--- a/src/core/llm/lmStudioProvider.ts
+++ b/src/core/llm/lmStudioProvider.ts
@@ -55,11 +55,16 @@ export class LmStudioProvider extends BaseLLMProvider<
     return this.adapter.streamResponse(this.client, request, options)
   }
 
-  async getEmbedding(model: string, text: string): Promise<number[]> {
+  async getEmbedding(
+    model: string,
+    text: string,
+    options?: { dimensions?: number },
+  ): Promise<number[]> {
     const embedding = await this.client.embeddings.create({
       model: model,
       input: text,
       encoding_format: 'float',
+      ...(options?.dimensions && { dimensions: options.dimensions }),
     })
     return embedding.data[0].embedding
   }

--- a/src/core/llm/mistralProvider.ts
+++ b/src/core/llm/mistralProvider.ts
@@ -56,7 +56,11 @@ export class MistralProvider extends BaseLLMProvider<
     return this.adapter.streamResponse(this.client, request, options)
   }
 
-  async getEmbedding(_model: string, _text: string): Promise<number[]> {
+  async getEmbedding(
+    _model: string,
+    _text: string,
+    _options?: { dimensions?: number },
+  ): Promise<number[]> {
     throw new Error(
       `Provider ${this.provider.id} does not support embeddings. Please use a different provider.`,
     )

--- a/src/core/llm/ollama.ts
+++ b/src/core/llm/ollama.ts
@@ -59,11 +59,16 @@ export class OllamaProvider extends BaseLLMProvider<
     return this.adapter.streamResponse(this.client, request, options)
   }
 
-  async getEmbedding(model: string, text: string): Promise<number[]> {
+  async getEmbedding(
+    model: string,
+    text: string,
+    options?: { dimensions?: number },
+  ): Promise<number[]> {
     const embedding = await this.client.embeddings.create({
       model: model,
       input: text,
       encoding_format: 'float',
+      ...(options?.dimensions && { dimensions: options.dimensions }),
     })
     return embedding.data[0].embedding
   }

--- a/src/core/llm/openRouterProvider.ts
+++ b/src/core/llm/openRouterProvider.ts
@@ -57,7 +57,11 @@ export class OpenRouterProvider extends BaseLLMProvider<
     return this.adapter.streamResponse(this.client, request, options)
   }
 
-  async getEmbedding(_model: string, _text: string): Promise<number[]> {
+  async getEmbedding(
+    _model: string,
+    _text: string,
+    _options?: { dimensions?: number },
+  ): Promise<number[]> {
     throw new Error(
       `Provider ${this.provider.id} does not support embeddings. Please use a different provider.`,
     )

--- a/src/core/llm/openai.ts
+++ b/src/core/llm/openai.ts
@@ -137,7 +137,11 @@ export class OpenAIAuthenticatedProvider extends BaseLLMProvider<
     }
   }
 
-  async getEmbedding(model: string, text: string): Promise<number[]> {
+  async getEmbedding(
+    model: string,
+    text: string,
+    options?: { dimensions?: number },
+  ): Promise<number[]> {
     if (!this.client.apiKey) {
       throw new LLMAPIKeyNotSetException(
         `Provider ${this.provider.id} API key is missing. Please set it in settings menu.`,
@@ -148,6 +152,7 @@ export class OpenAIAuthenticatedProvider extends BaseLLMProvider<
       const embedding = await this.client.embeddings.create({
         model: model,
         input: text,
+        ...(options?.dimensions && { dimensions: options.dimensions }),
       })
       return embedding.data[0].embedding
     } catch (error) {

--- a/src/core/llm/openaiCodexProvider.ts
+++ b/src/core/llm/openaiCodexProvider.ts
@@ -73,7 +73,11 @@ export class OpenAICodexProvider extends BaseLLMProvider<
     return this.adapter.streamResponse(normalizedRequest, options, authHeaders)
   }
 
-  async getEmbedding(_model: string, _text: string): Promise<number[]> {
+  async getEmbedding(
+    _model: string,
+    _text: string,
+    _options?: { dimensions?: number },
+  ): Promise<number[]> {
     throw new Error(
       `Provider ${this.provider.id} does not support embeddings. Please use a different provider.`,
     )

--- a/src/core/llm/openaiCompatibleProvider.ts
+++ b/src/core/llm/openaiCompatibleProvider.ts
@@ -80,11 +80,16 @@ export class OpenAICompatibleProvider extends BaseLLMProvider<
     return this.adapter.streamResponse(this.client, formattedRequest, options)
   }
 
-  async getEmbedding(model: string, text: string): Promise<number[]> {
+  async getEmbedding(
+    model: string,
+    text: string,
+    options?: { dimensions?: number },
+  ): Promise<number[]> {
     const embedding = await this.client.embeddings.create({
       model: model,
       input: text,
       encoding_format: 'float',
+      ...(options?.dimensions && { dimensions: options.dimensions }),
     })
     return embedding.data[0].embedding
   }

--- a/src/core/llm/perplexityProvider.ts
+++ b/src/core/llm/perplexityProvider.ts
@@ -82,7 +82,11 @@ export class PerplexityProvider extends BaseLLMProvider<
     return this.adapter.streamResponse(this.client, formattedRequest, options)
   }
 
-  async getEmbedding(_model: string, _text: string): Promise<number[]> {
+  async getEmbedding(
+    _model: string,
+    _text: string,
+    _options?: { dimensions?: number },
+  ): Promise<number[]> {
     throw new Error(
       `Provider ${this.provider.id} does not support embeddings. Please use a different provider.`,
     )

--- a/src/core/llm/xaiProvider.ts
+++ b/src/core/llm/xaiProvider.ts
@@ -57,7 +57,11 @@ export class XaiProvider extends BaseLLMProvider<
     return this.adapter.streamResponse(this.client, request, options)
   }
 
-  async getEmbedding(_model: string, _text: string): Promise<number[]> {
+  async getEmbedding(
+    _model: string,
+    _text: string,
+    _options?: { dimensions?: number },
+  ): Promise<number[]> {
     throw new Error(
       `Provider ${String(this.provider.id)} does not support embeddings. Please use a different provider.`,
     )

--- a/src/core/rag/embedding.ts
+++ b/src/core/rag/embedding.ts
@@ -25,6 +25,8 @@ export const getEmbeddingModelClient = ({
     id: embeddingModel.id,
     dimension: embeddingModel.dimension,
     getEmbedding: (text: string) =>
-      providerClient.getEmbedding(embeddingModel.model, text),
+      providerClient.getEmbedding(embeddingModel.model, text, {
+        dimensions: embeddingModel.outputDimension,
+      }),
   }
 }

--- a/src/types/embedding-model.types.ts
+++ b/src/types/embedding-model.types.ts
@@ -17,6 +17,10 @@ const baseEmbeddingModelSchema = z.object({
     })
     .min(1, 'model is required'),
   dimension: z.number(),
+  // Optional: Request specific output dimensions from the API.
+  // Only works with models that support Matryoshka Representation Learning (MRL),
+  // such as OpenAI's text-embedding-3-* and Google's gemini-embedding-001.
+  outputDimension: z.number().optional(),
 })
 
 // TODO: Ensure the embedding model schema only includes providers that genuinely support embeddings.


### PR DESCRIPTION
Closes #490 

## Description

Add optional outputDimension field for embedding models to request specific dimensions from providers that support Matryoshka Representation Learning (MRL).

Supported providers:
- OpenAI text-embedding-3-* (via 'dimensions' parameter)
- Google gemini-embedding-001 (via 'config.outputDimensionality')

Changes:
- Add outputDimension field to EmbeddingModel type
- Update all provider getEmbedding methods to accept dimensions option
- Add Output Dimensions input field in Add Embedding Model modal
- Validate that returned dimension matches requested outputDimension

## Checklist before requesting a review
- [x] I have reviewed the [guidelines for contributing](../CONTRIBUTING.md) to this repository.
- [x] I have performed a self-review of my code
- [x] I have performed a code linting check and type check (by running `npm run lint:check` and `npm run type:check`)
- [x] I have run the test suite (by running `npm run test`)
- [x] I have tested the functionality manually


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added an optional Output Dimensions field to embedding model settings, allowing you to specify custom embedding dimensions for compatible models.
  * Added validation that ensures requested dimensions are supported, with helpful error messages if they're not.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->