### PR TITLE
fix: improve visibility of waiting indicator in plan connect modals

### DIFF
--- a/src/components/settings/modals/ConnectGeminiPlanModal.tsx
+++ b/src/components/settings/modals/ConnectGeminiPlanModal.tsx
@@ -246,7 +246,13 @@ function ConnectGeminiPlanModalComponent({
         />
         {isWaitingForCallback && (
           <div className="smtcmp-plan-connect-waiting">
-            Waiting for authorization...
+            <div className="smtcmp-plan-connect-waiting-content">
+              <div className="smtcmp-plan-connect-waiting-spinner" />
+              <div className="smtcmp-plan-connect-waiting-text">
+                <strong>Waiting for authorization</strong>
+                <span>Complete the login in your browser, then return here</span>
+              </div>
+            </div>
           </div>
         )}
       </ObsidianSetting>

--- a/src/components/settings/modals/ConnectGeminiPlanModal.tsx
+++ b/src/components/settings/modals/ConnectGeminiPlanModal.tsx
@@ -250,7 +250,9 @@ function ConnectGeminiPlanModalComponent({
               <div className="smtcmp-plan-connect-waiting-spinner" />
               <div className="smtcmp-plan-connect-waiting-text">
                 <strong>Waiting for authorization</strong>
-                <span>Complete the login in your browser, then return here</span>
+                <span>
+                  Complete the login in your browser, then return here
+                </span>
               </div>
             </div>
           </div>

--- a/src/components/settings/modals/ConnectOpenAIPlanModal.tsx
+++ b/src/components/settings/modals/ConnectOpenAIPlanModal.tsx
@@ -246,7 +246,9 @@ function ConnectOpenAIPlanModalComponent({
               <div className="smtcmp-plan-connect-waiting-spinner" />
               <div className="smtcmp-plan-connect-waiting-text">
                 <strong>Waiting for authorization</strong>
-                <span>Complete the login in your browser, then return here</span>
+                <span>
+                  Complete the login in your browser, then return here
+                </span>
               </div>
             </div>
           </div>

--- a/src/components/settings/modals/ConnectOpenAIPlanModal.tsx
+++ b/src/components/settings/modals/ConnectOpenAIPlanModal.tsx
@@ -242,7 +242,13 @@ function ConnectOpenAIPlanModalComponent({
         />
         {isWaitingForCallback && (
           <div className="smtcmp-plan-connect-waiting">
-            Waiting for authorization...
+            <div className="smtcmp-plan-connect-waiting-content">
+              <div className="smtcmp-plan-connect-waiting-spinner" />
+              <div className="smtcmp-plan-connect-waiting-text">
+                <strong>Waiting for authorization</strong>
+                <span>Complete the login in your browser, then return here</span>
+              </div>
+            </div>
           </div>
         )}
       </ObsidianSetting>

--- a/styles.css
+++ b/styles.css
@@ -1872,8 +1872,51 @@ button.smtcmp-chat-input-model-select {
 }
 
 .smtcmp-plan-connect-waiting {
-  margin-top: var(--size-2-1);
-  font-size: var(--font-ui-small);
+  margin: var(--size-4-3) 0;
+  padding: var(--size-4-3);
+  background: var(--background-modifier-info);
+  border: 1px solid var(--background-modifier-border);
+  border-left: 3px solid var(--interactive-accent);
+  border-radius: var(--radius-s);
+}
+
+.smtcmp-plan-connect-waiting-content {
+  display: flex;
+  align-items: center;
+  gap: var(--size-4-3);
+}
+
+.smtcmp-plan-connect-waiting-spinner {
+  width: 20px;
+  height: 20px;
+  border: 2px solid var(--background-modifier-border);
+  border-top-color: var(--interactive-accent);
+  border-radius: 50%;
+  animation: smtcmp-spin 0.8s linear infinite;
+  flex-shrink: 0;
+}
+
+@keyframes smtcmp-spin {
+  from {
+    transform: rotate(0deg);
+  }
+  to {
+    transform: rotate(360deg);
+  }
+}
+
+.smtcmp-plan-connect-waiting-text {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+
+.smtcmp-plan-connect-waiting-text strong {
+  color: var(--text-normal);
+}
+
+.smtcmp-plan-connect-waiting-text span {
+  font-size: var(--font-ui-smaller);
   color: var(--text-muted);
 }
 


### PR DESCRIPTION
## Description

The "Waiting for authorization..." message was hard to see due to muted styling. Replace with a prominent banner featuring a spinner animation, accent border, and clear instructions.

## Checklist before requesting a review
- [x] I have reviewed the [guidelines for contributing](../CONTRIBUTING.md) to this repository.
- [x] I have performed a self-review of my code
- [x] I have performed a code linting check and type check (by running `npm run lint:check` and `npm run type:check`)
- [x] I have run the test suite (by running `npm run test`)
- [x] I have tested the functionality manually


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Enhanced plan connection authorization screens for Gemini and OpenAI integrations with visual loading indicators and clearer instructional messaging.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->