### PR TITLE
feat: add vault tools, context files, and datetime to system prompt

### DIFF
--- a/src/components/chat-view/useChatStreamManager.ts
+++ b/src/components/chat-view/useChatStreamManager.ts
@@ -4,7 +4,9 @@ import { useCallback, useMemo, useRef } from 'react'
 
 import { useApp } from '../../contexts/app-context'
 import { useMcp } from '../../contexts/mcp-context'
+import { useRAG } from '../../contexts/rag-context'
 import { useSettings } from '../../contexts/settings-context'
+import { VaultTools } from '../../core/vault-tools/vaultTools'
 import {
   LLMAPIKeyInvalidException,
   LLMAPIKeyNotSetException,
@@ -40,6 +42,11 @@ export function useChatStreamManager({
   const app = useApp()
   const { settings, setSettings } = useSettings()
   const { getMcpManager } = useMcp()
+  const { getRAGEngine } = useRAG()
+  const vaultTools = useMemo(
+    () => new VaultTools(app, getRAGEngine),
+    [app, getRAGEngine],
+  )
 
   const activeStreamAbortControllersRef = useRef<AbortController[]>([])
 
@@ -117,6 +124,7 @@ export function useChatStreamManager({
           maxAutoIterations: settings.chatOptions.maxAutoIterations,
           promptGenerator,
           mcpManager,
+          vaultTools,
           abortSignal: abortController.signal,
         })
 

--- a/src/components/settings/sections/ChatSection.tsx
+++ b/src/components/settings/sections/ChatSection.tsx
@@ -81,6 +81,31 @@ export function ChatSection() {
       </ObsidianSetting>
 
       <ObsidianSetting
+        name="Context files"
+        desc="Vault paths to automatically include in every chat (e.g. AGENTS.md, CLAUDE.md). One path per line."
+        className="smtcmp-settings-textarea-header"
+      />
+
+      <ObsidianSetting className="smtcmp-settings-textarea">
+        <ObsidianTextArea
+          value={settings.chatOptions.contextFiles.join('\n')}
+          onChange={async (value: string) => {
+            const files = value
+              .split('\n')
+              .map((p: string) => p.trim())
+              .filter((p: string) => p.length > 0)
+            await setSettings({
+              ...settings,
+              chatOptions: {
+                ...settings.chatOptions,
+                contextFiles: files,
+              },
+            })
+          }}
+        />
+      </ObsidianSetting>
+
+      <ObsidianSetting
         name="Include current file"
         desc="Automatically include the content of your current file in chats."
       >

--- a/src/core/vault-tools/vaultTools.test.ts
+++ b/src/core/vault-tools/vaultTools.test.ts
@@ -112,7 +112,7 @@ describe('VaultTools', () => {
   describe('vault_search_content', () => {
     it('returns RAG results when available', async () => {
       const ragResults = [
-        { path: 'notes/a.md', similarity: 0.9, metadata: { startLine: 1, endLine: 5 } },
+        { path: 'notes/a.md', content: 'matched chunk text', similarity: 0.9, metadata: { startLine: 1, endLine: 5 } },
       ]
       const getRagEngine = jest.fn().mockResolvedValue({
         processQuery: jest.fn().mockResolvedValue(ragResults),
@@ -122,6 +122,7 @@ describe('VaultTools', () => {
       expect(result.status).toBe(ToolCallResponseStatus.Success)
       if (result.status === ToolCallResponseStatus.Success) {
         expect(result.data.text).toContain('notes/a.md')
+        expect(result.data.text).toContain('matched chunk text')
       }
     })
 

--- a/src/core/vault-tools/vaultTools.test.ts
+++ b/src/core/vault-tools/vaultTools.test.ts
@@ -1,0 +1,146 @@
+import { App, TFile, TFolder } from 'obsidian'
+
+import { ToolCallResponseStatus } from '../../types/tool-call.types'
+import { VaultTools } from './vaultTools'
+
+function makeFile(path: string, name: string): TFile {
+  const f = new (TFile as unknown as new () => TFile)()
+  Object.assign(f, { path, name })
+  return f
+}
+
+function makeFolder(path: string, children: (TFile | TFolder)[] = []): TFolder {
+  const f = new (TFolder as unknown as new () => TFolder)()
+  Object.assign(f, { path, name: path.split('/').pop() ?? path, children })
+  return f
+}
+
+function makeApp(vaultOverrides: Record<string, unknown> = {}): App {
+  return {
+    vault: {
+      getAbstractFileByPath: jest.fn(),
+      getRoot: jest.fn(),
+      getFiles: jest.fn().mockReturnValue([]),
+      cachedRead: jest.fn().mockResolvedValue(''),
+      ...vaultOverrides,
+    },
+  } as unknown as App
+}
+
+describe('VaultTools', () => {
+  describe('isNativeTool', () => {
+    it('returns true only for exact vault tool names', () => {
+      const vt = new VaultTools(makeApp(), jest.fn())
+      expect(vt.isNativeTool('vault_read_file')).toBe(true)
+      expect(vt.isNativeTool('vault_list_directory')).toBe(true)
+      expect(vt.isNativeTool('vault_search_files')).toBe(true)
+      expect(vt.isNativeTool('vault_search_content')).toBe(true)
+      expect(vt.isNativeTool('mcp__server__tool')).toBe(false)
+      expect(vt.isNativeTool('vault__read_file')).toBe(false)
+      expect(vt.isNativeTool('vault_unknown')).toBe(false)
+    })
+  })
+
+  describe('listTools', () => {
+    it('returns 4 tool definitions', () => {
+      const vt = new VaultTools(makeApp(), jest.fn())
+      expect(vt.listTools()).toHaveLength(4)
+    })
+  })
+
+  describe('vault_read_file', () => {
+    it('returns file content on success', async () => {
+      const file = makeFile('notes/foo.md', 'foo.md')
+      const app = makeApp({
+        getAbstractFileByPath: jest.fn().mockReturnValue(file),
+        cachedRead: jest.fn().mockResolvedValue('hello'),
+      })
+      const vt = new VaultTools(app, jest.fn())
+      const result = await vt.callTool('vault_read_file', { path: 'notes/foo.md' })
+      expect(result.status).toBe(ToolCallResponseStatus.Success)
+      if (result.status === ToolCallResponseStatus.Success) {
+        expect(result.data.text).toBe('hello')
+      }
+    })
+
+    it('returns error when path not found', async () => {
+      const app = makeApp({ getAbstractFileByPath: jest.fn().mockReturnValue(null) })
+      const vt = new VaultTools(app, jest.fn())
+      const result = await vt.callTool('vault_read_file', { path: 'missing.md' })
+      expect(result.status).toBe(ToolCallResponseStatus.Error)
+    })
+  })
+
+  describe('vault_list_directory', () => {
+    it('lists root when no path given', async () => {
+      const folder = makeFolder('/')
+      const app = makeApp({ getRoot: jest.fn().mockReturnValue(folder) })
+      const vt = new VaultTools(app, jest.fn())
+      const result = await vt.callTool('vault_list_directory', {})
+      expect(result.status).toBe(ToolCallResponseStatus.Success)
+    })
+
+    it('returns error when path resolves to a file', async () => {
+      const file = makeFile('notes/foo.md', 'foo.md')
+      const app = makeApp({ getAbstractFileByPath: jest.fn().mockReturnValue(file) })
+      const vt = new VaultTools(app, jest.fn())
+      const result = await vt.callTool('vault_list_directory', { path: 'notes/foo.md' })
+      expect(result.status).toBe(ToolCallResponseStatus.Error)
+    })
+  })
+
+  describe('vault_search_files', () => {
+    it('returns matching file paths', async () => {
+      const files = [makeFile('notes/alpha.md', 'alpha.md'), makeFile('notes/beta.md', 'beta.md')]
+      const app = makeApp({ getFiles: jest.fn().mockReturnValue(files) })
+      const vt = new VaultTools(app, jest.fn())
+      const result = await vt.callTool('vault_search_files', { query: 'alpha' })
+      expect(result.status).toBe(ToolCallResponseStatus.Success)
+      if (result.status === ToolCallResponseStatus.Success) {
+        expect(result.data.text).toContain('notes/alpha.md')
+        expect(result.data.text).not.toContain('notes/beta.md')
+      }
+    })
+
+    it('returns error for empty query', async () => {
+      const vt = new VaultTools(makeApp(), jest.fn())
+      const result = await vt.callTool('vault_search_files', { query: '' })
+      expect(result.status).toBe(ToolCallResponseStatus.Error)
+    })
+  })
+
+  describe('vault_search_content', () => {
+    it('returns RAG results when available', async () => {
+      const ragResults = [
+        { path: 'notes/a.md', similarity: 0.9, metadata: { startLine: 1, endLine: 5 } },
+      ]
+      const getRagEngine = jest.fn().mockResolvedValue({
+        processQuery: jest.fn().mockResolvedValue(ragResults),
+      })
+      const vt = new VaultTools(makeApp(), getRagEngine)
+      const result = await vt.callTool('vault_search_content', { query: 'foo' })
+      expect(result.status).toBe(ToolCallResponseStatus.Success)
+      if (result.status === ToolCallResponseStatus.Success) {
+        expect(result.data.text).toContain('notes/a.md')
+      }
+    })
+
+    it('returns error when RAG fails', async () => {
+      const getRagEngine = jest.fn().mockRejectedValue(new Error('no index'))
+      const vt = new VaultTools(makeApp(), getRagEngine)
+      const result = await vt.callTool('vault_search_content', { query: 'foo' })
+      expect(result.status).toBe(ToolCallResponseStatus.Error)
+      if (result.status === ToolCallResponseStatus.Error) {
+        expect(result.error).toContain('no index')
+      }
+    })
+  })
+
+  describe('callTool', () => {
+    it('returns error for unknown tool name', async () => {
+      const vt = new VaultTools(makeApp(), jest.fn())
+      const result = await vt.callTool('vault_unknown', {})
+      expect(result.status).toBe(ToolCallResponseStatus.Error)
+    })
+  })
+})

--- a/src/core/vault-tools/vaultTools.test.ts
+++ b/src/core/vault-tools/vaultTools.test.ts
@@ -102,6 +102,30 @@ describe('VaultTools', () => {
       }
     })
 
+    it('matches case-insensitively', async () => {
+      const files = [makeFile('notes/Python-guide.md', 'Python-guide.md')]
+      const app = makeApp({ getFiles: jest.fn().mockReturnValue(files) })
+      const vt = new VaultTools(app, jest.fn())
+      const result = await vt.callTool('vault_search_files', { query: 'python' })
+      expect(result.status).toBe(ToolCallResponseStatus.Success)
+      if (result.status === ToolCallResponseStatus.Success) {
+        expect(result.data.text).toContain('notes/Python-guide.md')
+      }
+    })
+
+    it('truncates results beyond 50', async () => {
+      const files = Array.from({ length: 60 }, (_, i) =>
+        makeFile(`notes/note${i}.md`, `note${i}.md`),
+      )
+      const app = makeApp({ getFiles: jest.fn().mockReturnValue(files) })
+      const vt = new VaultTools(app, jest.fn())
+      const result = await vt.callTool('vault_search_files', { query: 'note' })
+      expect(result.status).toBe(ToolCallResponseStatus.Success)
+      if (result.status === ToolCallResponseStatus.Success) {
+        expect(result.data.text).toContain('10 more results truncated')
+      }
+    })
+
     it('returns error for empty query', async () => {
       const vt = new VaultTools(makeApp(), jest.fn())
       const result = await vt.callTool('vault_search_files', { query: '' })

--- a/src/core/vault-tools/vaultTools.ts
+++ b/src/core/vault-tools/vaultTools.ts
@@ -171,13 +171,23 @@ export class VaultTools {
         error: 'query must not be empty',
       }
     }
-    const matches = this.app.vault
+    const MAX_RESULTS = 50
+    const needle = query.toLowerCase()
+    const all = this.app.vault
       .getFiles()
-      .filter((f) => f.path.includes(query) || f.name.includes(query))
-      .map((f) => f.path)
+      .filter(
+        (f) =>
+          f.path.toLowerCase().includes(needle) ||
+          f.name.toLowerCase().includes(needle),
+      )
+    const matches = all.slice(0, MAX_RESULTS).map((f) => f.path)
+    const truncatedNote =
+      all.length > MAX_RESULTS
+        ? `\n... (${all.length - MAX_RESULTS} more results truncated)`
+        : ''
     return {
       status: ToolCallResponseStatus.Success,
-      data: { type: 'text', text: matches.join('\n') },
+      data: { type: 'text', text: matches.join('\n') + truncatedNote },
     }
   }
 

--- a/src/core/vault-tools/vaultTools.ts
+++ b/src/core/vault-tools/vaultTools.ts
@@ -1,0 +1,205 @@
+import { App, TFile, TFolder } from 'obsidian'
+
+import { RAGEngine } from '../rag/ragEngine'
+import { RequestTool } from '../../types/llm/request'
+import {
+  ToolCallResponse,
+  ToolCallResponseStatus,
+} from '../../types/tool-call.types'
+import { readTFileContent } from '../../utils/obsidian'
+
+type VaultToolName =
+  | 'vault_read_file'
+  | 'vault_list_directory'
+  | 'vault_search_files'
+  | 'vault_search_content'
+
+const VAULT_TOOL_NAMES: ReadonlySet<string> = new Set<VaultToolName>([
+  'vault_read_file',
+  'vault_list_directory',
+  'vault_search_files',
+  'vault_search_content',
+])
+
+export class VaultTools {
+  constructor(
+    private readonly app: App,
+    private readonly getRagEngine: () => Promise<RAGEngine>,
+  ) {}
+
+  isNativeTool(name: string): boolean {
+    return VAULT_TOOL_NAMES.has(name)
+  }
+
+  listTools(): RequestTool[] {
+    return [
+      {
+        type: 'function',
+        function: {
+          name: 'vault_read_file',
+          description: 'Read the content of a vault file by path',
+          parameters: {
+            type: 'object' as const,
+            properties: {
+              path: {
+                type: 'string',
+                description: 'Path to the file in the vault',
+              },
+            },
+            required: ['path'],
+          },
+        },
+      },
+      {
+        type: 'function',
+        function: {
+          name: 'vault_list_directory',
+          description: 'List files and folders in a vault directory',
+          parameters: {
+            type: 'object',
+            properties: {
+              path: {
+                type: 'string',
+                description:
+                  'Path to the directory (omit for vault root)',
+              },
+            },
+          },
+        },
+      },
+      {
+        type: 'function',
+        function: {
+          name: 'vault_search_files',
+          description: 'Search vault files by filename or path substring',
+          parameters: {
+            type: 'object' as const,
+            properties: {
+              query: { type: 'string', description: 'Search query', minLength: 1 },
+            },
+            required: ['query'],
+          },
+        },
+      },
+      {
+        type: 'function',
+        function: {
+          name: 'vault_search_content',
+          description:
+            'Search vault files by content using semantic search (RAG). Falls back to filename search if RAG is unavailable.',
+          parameters: {
+            type: 'object' as const,
+            properties: {
+              query: { type: 'string', description: 'Search query', minLength: 1 },
+            },
+            required: ['query'],
+          },
+        },
+      },
+    ]
+  }
+
+  async callTool(
+    name: string,
+    args: Record<string, unknown>,
+  ): Promise<ToolCallResponse> {
+    try {
+      switch (name as VaultToolName) {
+        case 'vault_read_file':
+          return await this.readFile(args.path as string)
+        case 'vault_list_directory':
+          return await this.listDirectory(args.path as string | undefined)
+        case 'vault_search_files':
+          return this.searchFiles(args.query as string)
+        case 'vault_search_content':
+          return await this.searchContent(args.query as string)
+        default:
+          return {
+            status: ToolCallResponseStatus.Error,
+            error: `Unknown vault tool: ${name}`,
+          }
+      }
+    } catch (error) {
+      return {
+        status: ToolCallResponseStatus.Error,
+        error: error instanceof Error ? error.message : String(error),
+      }
+    }
+  }
+
+  private async readFile(path: string): Promise<ToolCallResponse> {
+    const file = this.app.vault.getAbstractFileByPath(path)
+    if (!(file instanceof TFile)) {
+      return {
+        status: ToolCallResponseStatus.Error,
+        error: `File not found: ${path}`,
+      }
+    }
+    const content = await readTFileContent(file, this.app.vault)
+    return {
+      status: ToolCallResponseStatus.Success,
+      data: { type: 'text', text: content },
+    }
+  }
+
+  private async listDirectory(path?: string): Promise<ToolCallResponse> {
+    const folder =
+      !path || path === '/'
+        ? this.app.vault.getRoot()
+        : this.app.vault.getAbstractFileByPath(path)
+    if (!(folder instanceof TFolder)) {
+      return {
+        status: ToolCallResponseStatus.Error,
+        error: `Not a directory: ${path}`,
+      }
+    }
+    const entries = folder.children.map((child) => ({
+      name: child.name,
+      type: child instanceof TFolder ? 'folder' : 'file',
+      path: child.path,
+    }))
+    return {
+      status: ToolCallResponseStatus.Success,
+      data: { type: 'text', text: JSON.stringify(entries) },
+    }
+  }
+
+  private searchFiles(query: string): ToolCallResponse {
+    if (!query) {
+      return {
+        status: ToolCallResponseStatus.Error,
+        error: 'query must not be empty',
+      }
+    }
+    const matches = this.app.vault
+      .getFiles()
+      .filter((f) => f.path.includes(query) || f.name.includes(query))
+      .map((f) => f.path)
+    return {
+      status: ToolCallResponseStatus.Success,
+      data: { type: 'text', text: matches.join('\n') },
+    }
+  }
+
+  private async searchContent(query: string): Promise<ToolCallResponse> {
+    try {
+      const ragEngine = await this.getRagEngine()
+      const results = await ragEngine.processQuery({ query })
+      const mapped = results.map(({ path, similarity, metadata }) => ({
+        path,
+        similarity,
+        startLine: metadata?.startLine,
+        endLine: metadata?.endLine,
+      }))
+      return {
+        status: ToolCallResponseStatus.Success,
+        data: { type: 'text', text: JSON.stringify(mapped) },
+      }
+    } catch (error) {
+      return {
+        status: ToolCallResponseStatus.Error,
+        error: error instanceof Error ? error.message : String(error),
+      }
+    }
+  }
+}

--- a/src/core/vault-tools/vaultTools.ts
+++ b/src/core/vault-tools/vaultTools.ts
@@ -86,7 +86,7 @@ export class VaultTools {
         function: {
           name: 'vault_search_content',
           description:
-            'Search vault files by content using semantic search (RAG). Falls back to filename search if RAG is unavailable.',
+            'Search vault files by content using semantic search (RAG).',
           parameters: {
             type: 'object' as const,
             properties: {

--- a/src/core/vault-tools/vaultTools.ts
+++ b/src/core/vault-tools/vaultTools.ts
@@ -185,8 +185,9 @@ export class VaultTools {
     try {
       const ragEngine = await this.getRagEngine()
       const results = await ragEngine.processQuery({ query })
-      const mapped = results.map(({ path, similarity, metadata }) => ({
+      const mapped = results.map(({ path, content, similarity, metadata }) => ({
         path,
+        content,
         similarity,
         startLine: metadata?.startLine,
         endLine: metadata?.endLine,

--- a/src/settings/schema/migrations/16_to_17.test.ts
+++ b/src/settings/schema/migrations/16_to_17.test.ts
@@ -1,0 +1,18 @@
+import { migrateFrom16To17 } from './16_to_17'
+
+describe('Migration from v16 to v17', () => {
+  it('should increment version to 17', () => {
+    const oldSettings = { version: 16 }
+    const result = migrateFrom16To17(oldSettings)
+    expect(result.version).toBe(17)
+  })
+
+  it('should preserve existing settings', () => {
+    const oldSettings = {
+      version: 16,
+      chatOptions: { includeCurrentFileContent: true, enableTools: false },
+    }
+    const result = migrateFrom16To17(oldSettings)
+    expect(result.chatOptions).toEqual(oldSettings.chatOptions)
+  })
+})

--- a/src/settings/schema/migrations/16_to_17.ts
+++ b/src/settings/schema/migrations/16_to_17.ts
@@ -1,0 +1,5 @@
+import { SettingMigration } from '../setting.types'
+
+export const migrateFrom16To17: SettingMigration['migrate'] = (data) => {
+  return { ...data, version: 17 }
+}

--- a/src/settings/schema/migrations/index.ts
+++ b/src/settings/schema/migrations/index.ts
@@ -7,6 +7,7 @@ import { migrateFrom12To13 } from './12_to_13'
 import { migrateFrom13To14 } from './13_to_14'
 import { migrateFrom14To15 } from './14_to_15'
 import { migrateFrom15To16 } from './15_to_16'
+import { migrateFrom16To17 } from './16_to_17'
 import { migrateFrom1To2 } from './1_to_2'
 import { migrateFrom2To3 } from './2_to_3'
 import { migrateFrom3To4 } from './3_to_4'
@@ -17,7 +18,7 @@ import { migrateFrom7To8 } from './7_to_8'
 import { migrateFrom8To9 } from './8_to_9'
 import { migrateFrom9To10 } from './9_to_10'
 
-export const SETTINGS_SCHEMA_VERSION = 16
+export const SETTINGS_SCHEMA_VERSION = 17
 
 export const SETTING_MIGRATIONS: SettingMigration[] = [
   {
@@ -99,5 +100,10 @@ export const SETTING_MIGRATIONS: SettingMigration[] = [
     fromVersion: 15,
     toVersion: 16,
     migrate: migrateFrom15To16,
+  },
+  {
+    fromVersion: 16,
+    toVersion: 17,
+    migrate: migrateFrom16To17,
   },
 ]

--- a/src/settings/schema/setting.types.ts
+++ b/src/settings/schema/setting.types.ts
@@ -81,11 +81,13 @@ export const smartComposerSettingsSchema = z.object({
       includeCurrentFileContent: z.boolean(),
       enableTools: z.boolean(),
       maxAutoIterations: z.number(),
+      contextFiles: z.array(z.string()).catch([]),
     })
     .catch({
       includeCurrentFileContent: true,
       enableTools: true,
       maxAutoIterations: 1,
+      contextFiles: [],
     }),
 })
 export type SmartComposerSettings = z.infer<typeof smartComposerSettingsSchema>

--- a/src/settings/schema/settings.test.ts
+++ b/src/settings/schema/settings.test.ts
@@ -43,6 +43,7 @@ describe('parseSmartComposerSettings', () => {
         includeCurrentFileContent: true,
         enableTools: true,
         maxAutoIterations: 1,
+        contextFiles: [],
       },
     })
   })

--- a/src/types/llm/request.ts
+++ b/src/types/llm/request.ts
@@ -119,5 +119,6 @@ type FunctionDescription = {
   parameters: {
     type: 'object'
     properties: Record<string, unknown>
+    required?: string[]
   }
 }

--- a/src/utils/chat/promptGenerator.ts
+++ b/src/utils/chat/promptGenerator.ts
@@ -452,7 +452,8 @@ ${
 The user has full access to the file, so they prefer seeing only the changes in the markdown. Often this will mean that the start/end of the file will be skipped, but that's okay! Rewrite the entire file only if specifically requested. Always provide a brief explanation of the updates, except when the user specifically asks for just the content.
 `
     : ''
-}`
+}
+Today's date and time is ${new Date().toISOString()} (${Intl.DateTimeFormat().resolvedOptions().timeZone}).`
 
     const systemPromptRAG = `You are an intelligent assistant to help answer any questions that the user has${modelPromptLevel == PromptLevel.Default ? `, particularly about editing and organizing markdown files in Obsidian` : ''}. You will be given your conversation history with them and potentially relevant blocks of markdown content from the current vault.
       
@@ -481,7 +482,8 @@ ${
   d. When referencing a markdown block the user gives you, only add the startLine and endLine attributes to the <smtcmp_block> tags. Write related content outside of the <smtcmp_block> tags. The content inside the <smtcmp_block> tags will be ignored and replaced with the actual content of the markdown block. For example:
   <smtcmp_block filename="path/to/file.md" language="markdown" startLine="2" endLine="30"></smtcmp_block>`
     : ''
-}`
+}
+Today's date and time is ${new Date().toISOString()} (${Intl.DateTimeFormat().resolvedOptions().timeZone}).`
 
     return {
       role: 'system',

--- a/src/utils/chat/promptGenerator.ts
+++ b/src/utils/chat/promptGenerator.ts
@@ -88,7 +88,7 @@ export class PromptGenerator {
     }
     const shouldUseRAG = lastUserMessage.similaritySearchResults !== undefined
 
-    const systemMessage = this.getSystemMessage(shouldUseRAG)
+    const systemMessage = await this.getSystemMessage(shouldUseRAG)
 
     const customInstructionMessage = this.getCustomInstructionMessage()
 
@@ -100,12 +100,9 @@ export class PromptGenerator {
         ? await this.getCurrentFileMessage(currentFile)
         : undefined
 
-    const contextFilesMessages = await this.getContextFilesMessages()
-
     const requestMessages: RequestMessage[] = [
       systemMessage,
       ...(customInstructionMessage ? [customInstructionMessage] : []),
-      ...contextFilesMessages,
       ...(currentFileMessage ? [currentFileMessage] : []),
       ...this.getChatHistoryMessages({ messages: compiledMessages }),
       ...(shouldUseRAG && this.getModelPromptLevel() == PromptLevel.Default
@@ -414,8 +411,9 @@ ${await this.getWebsiteContent(url)}
     }
   }
 
-  private getSystemMessage(shouldUseRAG: boolean): RequestMessage {
+  private async getSystemMessage(shouldUseRAG: boolean): Promise<RequestMessage> {
     const modelPromptLevel = this.getModelPromptLevel()
+    const contextFilesSection = await this.getContextFilesSection()
     const systemPrompt = `You are an intelligent assistant to help answer any questions that the user has${modelPromptLevel == PromptLevel.Default ? `, particularly about editing and organizing markdown files in Obsidian` : ''}.
 
 1. Please keep your response as concise as possible. Avoid being verbose.
@@ -453,10 +451,10 @@ The user has full access to the file, so they prefer seeing only the changes in 
 `
     : ''
 }
-Today's date and time is ${new Date().toLocaleString()} (${Intl.DateTimeFormat().resolvedOptions().timeZone}).`
+Today's date and time is ${new Date().toLocaleString()} (${Intl.DateTimeFormat().resolvedOptions().timeZone}).${contextFilesSection}`
 
     const systemPromptRAG = `You are an intelligent assistant to help answer any questions that the user has${modelPromptLevel == PromptLevel.Default ? `, particularly about editing and organizing markdown files in Obsidian` : ''}. You will be given your conversation history with them and potentially relevant blocks of markdown content from the current vault.
-      
+
 1. Do not lie or make up facts.
 
 2. Format your response in markdown.
@@ -483,12 +481,24 @@ ${
   <smtcmp_block filename="path/to/file.md" language="markdown" startLine="2" endLine="30"></smtcmp_block>`
     : ''
 }
-Today's date and time is ${new Date().toLocaleString()} (${Intl.DateTimeFormat().resolvedOptions().timeZone}).`
+Today's date and time is ${new Date().toLocaleString()} (${Intl.DateTimeFormat().resolvedOptions().timeZone}).${contextFilesSection}`
 
     return {
       role: 'system',
       content: shouldUseRAG ? systemPromptRAG : systemPrompt,
     }
+  }
+
+  private async getContextFilesSection(): Promise<string> {
+    const paths = this.settings.chatOptions.contextFiles ?? []
+    const parts: string[] = []
+    for (const path of paths) {
+      const file = this.app.vault.getAbstractFileByPath(path)
+      if (!(file instanceof TFile)) continue
+      const content = await readTFileContent(file, this.app.vault)
+      parts.push(`<context_file filename="${path}">\n${content}\n</context_file>`)
+    }
+    return parts.length > 0 ? `\n\n${parts.join('\n\n')}` : ''
   }
 
   private getCustomInstructionMessage(): RequestMessage | null {
@@ -505,20 +515,6 @@ ${customInstruction}
     }
   }
 
-  private async getContextFilesMessages(): Promise<RequestMessage[]> {
-    const paths = this.settings.chatOptions.contextFiles ?? []
-    const messages: RequestMessage[] = []
-    for (const path of paths) {
-      const file = this.app.vault.getAbstractFileByPath(path)
-      if (!(file instanceof TFile)) continue
-      const content = await readTFileContent(file, this.app.vault)
-      messages.push({
-        role: 'user',
-        content: `Here is the content of ${path} for additional context:\n<context_file filename="${path}">\n${content}\n</context_file>`,
-      })
-    }
-    return messages
-  }
 
   private async getCurrentFileMessage(
     currentFile: TFile,

--- a/src/utils/chat/promptGenerator.ts
+++ b/src/utils/chat/promptGenerator.ts
@@ -100,9 +100,12 @@ export class PromptGenerator {
         ? await this.getCurrentFileMessage(currentFile)
         : undefined
 
+    const contextFilesMessages = await this.getContextFilesMessages()
+
     const requestMessages: RequestMessage[] = [
       systemMessage,
       ...(customInstructionMessage ? [customInstructionMessage] : []),
+      ...contextFilesMessages,
       ...(currentFileMessage ? [currentFileMessage] : []),
       ...this.getChatHistoryMessages({ messages: compiledMessages }),
       ...(shouldUseRAG && this.getModelPromptLevel() == PromptLevel.Default
@@ -498,6 +501,21 @@ ${
 ${customInstruction}
 </custom_instructions>`,
     }
+  }
+
+  private async getContextFilesMessages(): Promise<RequestMessage[]> {
+    const paths = this.settings.chatOptions.contextFiles ?? []
+    const messages: RequestMessage[] = []
+    for (const path of paths) {
+      const file = this.app.vault.getAbstractFileByPath(path)
+      if (!(file instanceof TFile)) continue
+      const content = await readTFileContent(file, this.app.vault)
+      messages.push({
+        role: 'user',
+        content: `Here is the content of ${path} for additional context:\n<context_file filename="${path}">\n${content}\n</context_file>`,
+      })
+    }
+    return messages
   }
 
   private async getCurrentFileMessage(

--- a/src/utils/chat/promptGenerator.ts
+++ b/src/utils/chat/promptGenerator.ts
@@ -453,7 +453,7 @@ The user has full access to the file, so they prefer seeing only the changes in 
 `
     : ''
 }
-Today's date and time is ${new Date().toISOString()} (${Intl.DateTimeFormat().resolvedOptions().timeZone}).`
+Today's date and time is ${new Date().toLocaleString()} (${Intl.DateTimeFormat().resolvedOptions().timeZone}).`
 
     const systemPromptRAG = `You are an intelligent assistant to help answer any questions that the user has${modelPromptLevel == PromptLevel.Default ? `, particularly about editing and organizing markdown files in Obsidian` : ''}. You will be given your conversation history with them and potentially relevant blocks of markdown content from the current vault.
       
@@ -483,7 +483,7 @@ ${
   <smtcmp_block filename="path/to/file.md" language="markdown" startLine="2" endLine="30"></smtcmp_block>`
     : ''
 }
-Today's date and time is ${new Date().toISOString()} (${Intl.DateTimeFormat().resolvedOptions().timeZone}).`
+Today's date and time is ${new Date().toLocaleString()} (${Intl.DateTimeFormat().resolvedOptions().timeZone}).`
 
     return {
       role: 'system',

--- a/src/utils/chat/promptGenerator.ts
+++ b/src/utils/chat/promptGenerator.ts
@@ -494,7 +494,10 @@ Today's date and time is ${new Date().toLocaleString()} (${Intl.DateTimeFormat()
     const parts: string[] = []
     for (const path of paths) {
       const file = this.app.vault.getAbstractFileByPath(path)
-      if (!(file instanceof TFile)) continue
+      if (!(file instanceof TFile)) {
+        console.warn(`[smart-composer] Context file not found or is not a file: ${path}`)
+        continue
+      }
       const content = await readTFileContent(file, this.app.vault)
       parts.push(`<context_file filename="${path}">\n${content}\n</context_file>`)
     }

--- a/src/utils/chat/responseGenerator.ts
+++ b/src/utils/chat/responseGenerator.ts
@@ -106,9 +106,16 @@ export class ResponseGenerator {
           .map(async (toolCall) => {
             let parsedArgs: Record<string, unknown> | null = null
             try {
-              parsedArgs = toolCall.request.arguments
+              const parsed = toolCall.request.arguments
                 ? JSON.parse(toolCall.request.arguments)
                 : {}
+              if (
+                typeof parsed === 'object' &&
+                parsed !== null &&
+                !Array.isArray(parsed)
+              ) {
+                parsedArgs = parsed as Record<string, unknown>
+              }
             } catch (e) {
               // handled below
             }
@@ -126,6 +133,7 @@ export class ResponseGenerator {
                       id: toolCall.request.id,
                       signal: this.abortSignal,
                     })
+            if (this.abortSignal?.aborted) return
             this.updateResponseMessages((messages) =>
               messages.map((message) =>
                 message.id === toolMessage.id && message.role === 'tool'

--- a/src/utils/chat/responseGenerator.ts
+++ b/src/utils/chat/responseGenerator.ts
@@ -16,6 +16,8 @@ import {
   ToolCallResponseStatus,
 } from '../../types/tool-call.types'
 
+import { VaultTools } from '../../core/vault-tools/vaultTools'
+
 import { fetchAnnotationTitles } from './fetch-annotation-titles'
 import { PromptGenerator } from './promptGenerator'
 
@@ -28,6 +30,7 @@ export type ResponseGeneratorParams = {
   maxAutoIterations: number
   promptGenerator: PromptGenerator
   mcpManager: McpManager
+  vaultTools: VaultTools
   abortSignal?: AbortSignal
 }
 
@@ -38,6 +41,7 @@ export class ResponseGenerator {
   private readonly enableTools: boolean
   private readonly promptGenerator: PromptGenerator
   private readonly mcpManager: McpManager
+  private readonly vaultTools: VaultTools
   private readonly abortSignal?: AbortSignal
   private readonly receivedMessages: ChatMessage[]
   private readonly maxAutoIterations: number
@@ -54,6 +58,7 @@ export class ResponseGenerator {
     this.receivedMessages = params.messages
     this.promptGenerator = params.promptGenerator
     this.mcpManager = params.mcpManager
+    this.vaultTools = params.vaultTools
     this.abortSignal = params.abortSignal
   }
 
@@ -78,12 +83,14 @@ export class ResponseGenerator {
         toolCalls: toolCallRequests.map((toolCall) => ({
           request: toolCall,
           response: {
-            status: this.mcpManager.isToolExecutionAllowed({
-              requestToolName: toolCall.name,
-              conversationId: this.conversationId,
-            })
-              ? ToolCallResponseStatus.Running
-              : ToolCallResponseStatus.PendingApproval,
+            status:
+              this.vaultTools.isNativeTool(toolCall.name) ||
+              this.mcpManager.isToolExecutionAllowed({
+                requestToolName: toolCall.name,
+                conversationId: this.conversationId,
+              })
+                ? ToolCallResponseStatus.Running
+                : ToolCallResponseStatus.PendingApproval,
           },
         })),
       }
@@ -97,12 +104,28 @@ export class ResponseGenerator {
               toolCall.response.status === ToolCallResponseStatus.Running,
           )
           .map(async (toolCall) => {
-            const response = await this.mcpManager.callTool({
-              name: toolCall.request.name,
-              args: toolCall.request.arguments,
-              id: toolCall.request.id,
-              signal: this.abortSignal,
-            })
+            let parsedArgs: Record<string, unknown> | null = null
+            try {
+              parsedArgs = toolCall.request.arguments
+                ? JSON.parse(toolCall.request.arguments)
+                : {}
+            } catch (e) {
+              // handled below
+            }
+            const response =
+              parsedArgs === null
+                ? ({
+                    status: ToolCallResponseStatus.Error,
+                    error: `Invalid tool arguments: ${toolCall.request.arguments}`,
+                  } as const)
+                : this.vaultTools.isNativeTool(toolCall.request.name)
+                  ? await this.vaultTools.callTool(toolCall.request.name, parsedArgs)
+                  : await this.mcpManager.callTool({
+                      name: toolCall.request.name,
+                      args: toolCall.request.arguments,
+                      id: toolCall.request.id,
+                      signal: this.abortSignal,
+                    })
             this.updateResponseMessages((messages) =>
               messages.map((message) =>
                 message.id === toolMessage.id && message.role === 'tool'
@@ -148,26 +171,30 @@ export class ResponseGenerator {
       messages: [...this.receivedMessages, ...this.responseMessages],
     })
 
-    const availableTools = this.enableTools
+    const availableMcpTools = this.enableTools
       ? await this.mcpManager.listAvailableTools()
+      : []
+
+    const mcpToolDefs: RequestTool[] = availableMcpTools.map((tool) => ({
+      type: 'function',
+      function: {
+        name: tool.name,
+        description: tool.description,
+        parameters: {
+          ...tool.inputSchema,
+          properties: tool.inputSchema.properties ?? {},
+        },
+      },
+    }))
+
+    const allTools = this.enableTools
+      ? [...this.vaultTools.listTools(), ...mcpToolDefs]
       : []
 
     // Set tools to undefined when no tools are available since some providers
     // reject empty tools arrays.
     const tools: RequestTool[] | undefined =
-      availableTools.length > 0
-        ? availableTools.map((tool) => ({
-            type: 'function',
-            function: {
-              name: tool.name,
-              description: tool.description,
-              parameters: {
-                ...tool.inputSchema,
-                properties: tool.inputSchema.properties ?? {},
-              },
-            },
-          }))
-        : undefined
+      allTools.length > 0 ? allTools : undefined
 
     const stream = await this.providerClient.streamResponse(
       this.model,


### PR DESCRIPTION
## Summary

- **Vault tools**: Adds `src/core/vault-tools/vaultTools.ts` with file search, directory listing, and content search tools available to the LLM during chat
<img width="300" alt="image" src="https://github.com/user-attachments/assets/416ef051-b07f-48da-83f8-c75880fdd86f" />

<img width="300"   alt="image" src="https://github.com/user-attachments/assets/11ecefa9-f036-45f3-af9b-21e0ab528f34" />

- **Context files**: Adds a setting to include `AGENTS.md` / `CLAUDE.md` vault files as automatic system prompt context
<img width="300" alt="image" src="https://github.com/user-attachments/assets/2c6598a7-de0e-4c6b-89f8-eb5533826608" />

- **Datetime in system prompt**: Injects current date/time and timezone into the system prompt so the model has temporal awareness

<img width="300" alt="image" src="https://github.com/user-attachments/assets/050f2a1b-2edb-4e9f-a6f2-4e7627703da2" />


## Changes

- `src/core/vault-tools/vaultTools.ts` — new vault tool implementations (search files, list directory, read file content)
- `src/settings/schema/setting.types.ts` + `migrations/16_to_17.ts` — new `contextFiles` setting (schema v17)
- `src/utils/chat/promptGenerator.ts` + `responseGenerator.ts` — wire context files and datetime into prompt/response pipeline
- `src/components/settings/sections/ChatSection.tsx` — UI for context files setting
- `src/components/chat-view/useChatStreamManager.ts` — pass vault tools to stream manager

## Test plan

- [x] `src/core/vault-tools/vaultTools.test.ts` — unit tests for all vault tool implementations
- [x] `src/settings/schema/migrations/16_to_17.test.ts` — migration unit test
- [ ] Manual: enable context files in settings → AGENTS.md content appears in system prompt
- [ ] Manual: ask model "what time is it?" → responds with current date/time
- [ ] Manual: use vault search tool in chat → returns relevant files

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * "Context files" chat setting: textarea to list vault files whose contents are embedded into system prompts.
  * LLMs can use native vault tools (read file, list directory, filename search, semantic content search) surfaced alongside other tools.
  * System prompt now includes current date/time, timezone, and injected context-files content.

* **Chores**
  * Settings schema bumped to version 17 with a migration and defaulting of chatOptions.contextFiles to [].

* **Tests**
  * Added tests covering vault tools and the migration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->